### PR TITLE
Add macro for defining scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,37 +81,40 @@ fn main() {
     let previous_rank = if rank > 0 { rank - 1 } else { size - 1 };
 
     let msg = vec![rank, 2 * rank, 4 * rank];
-    mpi::request::scope(|scope| {
-        let _sreq = WaitGuard::from(
-            world
-                .process_at_rank(next_rank)
-                .immediate_send(scope, &msg[..]),
-        );
 
-        let (msg, status) = world.any_process().receive_vec();
+    // Defining scopes ensures that all borrowed buffers live until all requests
+    // that borrow them complete.
+    mpi::define_scope!(scope);
 
-        println!(
-            "Process {} got message {:?}.\nStatus is: {:?}",
-            rank, msg, status
-        );
-        let x = status.source_rank();
-        assert_eq!(x, previous_rank);
-        assert_eq!(vec![x, 2 * x, 4 * x], msg);
+    let _sreq = WaitGuard::from(
+        world
+            .process_at_rank(next_rank)
+            .immediate_send(scope, &msg[..]),
+    );
 
-        let root_rank = 0;
-        let root_process = world.process_at_rank(root_rank);
+    let (msg, status) = world.any_process().receive_vec();
 
-        let mut a;
-        if world.rank() == root_rank {
-            a = vec![2, 4, 8, 16];
-            println!("Root broadcasting value: {:?}.", &a[..]);
-        } else {
-            a = vec![0; 4];
-        }
-        root_process.broadcast_into(&mut a[..]);
-        println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
-        assert_eq!(&a[..], &[2, 4, 8, 16]);
-    });
+    println!(
+        "Process {} got message {:?}.\nStatus is: {:?}",
+        rank, msg, status
+    );
+    let x = status.source_rank();
+    assert_eq!(x, previous_rank);
+    assert_eq!(vec![x, 2 * x, 4 * x], msg);
+
+    let root_rank = 0;
+    let root_process = world.process_at_rank(root_rank);
+
+    let mut a;
+    if world.rank() == root_rank {
+        a = vec![2, 4, 8, 16];
+        println!("Root broadcasting value: {:?}.", &a[..]);
+    } else {
+        a = vec![0; 4];
+    }
+    root_process.broadcast_into(&mut a[..]);
+    println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
+    assert_eq!(&a[..], &[2, 4, 8, 16]);
 }
 ```
 

--- a/examples/buffered.rs
+++ b/examples/buffered.rs
@@ -21,13 +21,15 @@ fn main() {
 
     let x = vec![std::f32::consts::PI; 1024];
     let mut y = vec![0.0; 1024];
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
+
         let _rreq = WaitGuard::from(
             world
                 .any_process()
                 .immediate_receive_into(scope, &mut y[..]),
         );
         world.this_process().buffered_send(&x[..]);
-    });
+    }
     assert_eq!(x, y);
 }

--- a/examples/immediate.rs
+++ b/examples/immediate.rs
@@ -2,8 +2,10 @@
 #![allow(clippy::float_cmp)]
 extern crate mpi;
 
-use mpi::request::{CancelGuard, WaitGuard};
+use mpi::request::{CancelGuard, LocalScope, WaitGuard};
 use mpi::traits::*;
+
+use std::pin::Pin;
 
 fn main() {
     let universe = mpi::initialize().unwrap();
@@ -12,9 +14,15 @@ fn main() {
     let x = std::f32::consts::PI;
     let mut y: f32 = 0.0;
 
-    mpi::request::scope(|scope| {
+    {
+        // Scopes can be defined using the `define_scope!` macro. This is the preferred method.
+        // A scope should be dropped as soon as the requests attached to it complete so that
+        // any borrowed state can be used.
+        mpi::define_scope!(scope);
+
         let mut sreq = world.this_process().immediate_send(scope, &x);
         let rreq = world.any_process().immediate_receive_into(scope, &mut y);
+
         rreq.wait();
         loop {
             match sreq.test() {
@@ -26,20 +34,30 @@ fn main() {
                 }
             }
         }
-    });
+    }
+
     assert_eq!(x, y);
 
     y = 0.0;
-    mpi::request::scope(|scope| {
-        let _rreq = WaitGuard::from(world.any_process().immediate_receive_into(scope, &mut y));
+    {
+        // Scopes can also be pinned to the heap, though this has some overhead. This scope must
+        // be passed by reference, or you must convert it into a `Pin<&LocalScope>` using
+        // `as_ref()`.
+        let scope: Pin<Box<LocalScope>> = LocalScope::pinned();
+
+        let _rreq = WaitGuard::from(world.any_process().immediate_receive_into(&scope, &mut y));
+
+        // Converts to a `Pin<&LocalScope>`, which can be passed directly to immediate routines.
+        let scope: Pin<&LocalScope> = scope.as_ref();
         let _sreq = WaitGuard::from(world.this_process().immediate_ready_send(scope, &x));
-    });
+    }
     assert_eq!(x, y);
 
     assert!(world.any_process().immediate_probe().is_none());
     assert!(world.any_process().immediate_matched_probe().is_none());
 
     y = 0.0;
+    // last of all, you can use the `scope` routine
     mpi::request::scope(|scope| {
         let _sreq: WaitGuard<_> = world
             .this_process()
@@ -74,11 +92,11 @@ fn main() {
         }
     }
 
-    mpi::request::scope(|scope| {
-        let sreq = world.this_process().immediate_send(scope, &x);
-        sreq.cancel();
-        sreq.wait();
+    mpi::define_scope!(scope);
 
-        let _sreq = CancelGuard::from(world.this_process().immediate_receive_into(scope, &mut y));
-    });
+    let sreq = world.this_process().immediate_send(scope, &x);
+    sreq.cancel();
+    sreq.wait();
+
+    let _sreq = CancelGuard::from(world.this_process().immediate_receive_into(scope, &mut y));
 }

--- a/examples/immediate_all_gather.rs
+++ b/examples/immediate_all_gather.rs
@@ -14,11 +14,13 @@ fn main() {
     let i = 2_u64.pow(world.rank() as u32 + 1);
     let mut a = vec![0u64; count];
 
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
+
         world
             .immediate_all_gather_into(scope, &i, &mut a[..])
             .wait();
-    });
+    }
 
     if world.rank() == root_rank {
         println!("Root gathered sequence: {:?}.", a);
@@ -35,11 +37,13 @@ fn main() {
         .collect::<Vec<_>>();
     let mut t = vec![0u64; count * count];
 
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
+
         world
             .immediate_all_gather_into(scope, &a[..], &mut t[..])
             .wait();
-    });
+    }
 
     if world.rank() == root_rank {
         println!("Root gathered table:");
@@ -57,9 +61,9 @@ fn main() {
     {
         let sv = unsafe { View::with_count_and_datatype(&a[..], 1, &d) };
         let mut rv = unsafe { MutView::with_count_and_datatype(&mut t[..], count as Count, &d) };
-        mpi::request::scope(|scope| {
-            world.immediate_all_gather_into(scope, &sv, &mut rv).wait();
-        });
+
+        mpi::define_scope!(scope);
+        world.immediate_all_gather_into(scope, &sv, &mut rv).wait();
     }
 
     if world.rank() == root_rank {

--- a/examples/immediate_all_gather_varcount.rs
+++ b/examples/immediate_all_gather_varcount.rs
@@ -27,10 +27,11 @@ fn main() {
     let mut buf = vec![0; (size * (size - 1) / 2) as usize];
     {
         let mut partition = PartitionMut::new(&mut buf[..], counts, &displs[..]);
-        mpi::request::scope(|scope| {
-            let req = world.immediate_all_gather_varcount_into(scope, &msg[..], &mut partition);
-            req.wait();
-        });
+
+        mpi::define_scope!(scope);
+        world
+            .immediate_all_gather_varcount_into(scope, &msg[..], &mut partition)
+            .wait();
     }
 
     assert!(buf

--- a/examples/immediate_all_to_all.rs
+++ b/examples/immediate_all_to_all.rs
@@ -12,11 +12,13 @@ fn main() {
     let u = vec![rank; size as usize];
     let mut v = vec![0; size as usize];
 
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
+
         world
             .immediate_all_to_all_into(scope, &u[..], &mut v[..])
             .wait();
-    });
+    }
 
     println!("u: {:?}", u);
     println!("v: {:?}", v);

--- a/examples/immediate_broadcast.rs
+++ b/examples/immediate_broadcast.rs
@@ -16,9 +16,12 @@ fn main() {
     } else {
         x = 0_u64;
     }
-    mpi::request::scope(|scope| {
+
+    {
+        mpi::define_scope!(scope);
         root_process.immediate_broadcast_into(scope, &mut x).wait();
-    });
+    }
+
     println!("Rank {} received value: {}.", world.rank(), x);
     assert_eq!(x, 1024);
     println!();
@@ -31,11 +34,14 @@ fn main() {
     } else {
         a = std::iter::repeat(0_u64).take(n).collect::<Vec<_>>();
     }
-    mpi::request::scope(|scope| {
+
+    {
+        mpi::define_scope!(scope);
         root_process
             .immediate_broadcast_into(scope, &mut a[..])
             .wait();
-    });
+    }
+
     println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
     assert_eq!(&a[..], &[2, 4, 8, 16]);
 }

--- a/examples/immediate_gather_varcount.rs
+++ b/examples/immediate_gather_varcount.rs
@@ -31,11 +31,12 @@ fn main() {
         let mut buf = vec![0; (size * (size - 1) / 2) as usize];
         {
             let mut partition = PartitionMut::new(&mut buf[..], counts, &displs[..]);
-            mpi::request::scope(|scope| {
+            {
+                mpi::define_scope!(scope);
                 root_process
                     .immediate_gather_varcount_into_root(scope, &msg[..], &mut partition)
                     .wait();
-            })
+            }
         }
 
         assert!(buf
@@ -44,10 +45,9 @@ fn main() {
             .all(|(&i, j)| i == j));
         println!("{:?}", buf);
     } else {
-        mpi::request::scope(|scope| {
-            root_process
-                .immediate_gather_varcount_into(scope, &msg[..])
-                .wait();
-        });
+        mpi::define_scope!(scope);
+        root_process
+            .immediate_gather_varcount_into(scope, &msg[..])
+            .wait();
     }
 }

--- a/examples/immediate_scan.rs
+++ b/examples/immediate_scan.rs
@@ -15,20 +15,22 @@ fn main() {
     let rank = world.rank();
 
     let mut x = 0;
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
         world
             .immediate_scan_into(scope, &rank, &mut x, SystemOperation::sum())
             .wait();
-    });
+    }
     assert_eq!(x, (rank * (rank + 1)) / 2);
 
     let y = rank + 1;
     let mut z = 0;
-    mpi::request::scope(|scope| {
+    {
+        mpi::define_scope!(scope);
         world
             .immediate_exclusive_scan_into(scope, &y, &mut z, SystemOperation::product())
             .wait();
-    });
+    }
     if rank > 0 {
         assert_eq!(z, fac(y - 1));
     }

--- a/examples/immediate_scatter.rs
+++ b/examples/immediate_scatter.rs
@@ -15,15 +15,14 @@ fn main() {
     let mut x = 0 as Rank;
     if rank == root_rank {
         let v = (0..size).collect::<Vec<_>>();
-        mpi::request::scope(|scope| {
-            let req = root_process.immediate_scatter_into_root(scope, &v[..], &mut x);
-            req.wait();
-        });
+
+        mpi::define_scope!(scope);
+        root_process
+            .immediate_scatter_into_root(scope, &v[..], &mut x)
+            .wait();
     } else {
-        mpi::request::scope(|scope| {
-            let req = root_process.immediate_scatter_into(scope, &mut x);
-            req.wait();
-        });
+        mpi::define_scope!(scope);
+        root_process.immediate_scatter_into(scope, &mut x).wait();
     }
     assert_eq!(x, rank);
 }

--- a/examples/immediate_scatter_varcount.rs
+++ b/examples/immediate_scatter_varcount.rs
@@ -29,17 +29,17 @@ fn main() {
             })
             .collect();
         let partition = Partition::new(&msg[..], counts, &displs[..]);
-        mpi::request::scope(|scope| {
-            root_process
-                .immediate_scatter_varcount_into_root(scope, &partition, &mut buf[..])
-                .wait();
-        });
+
+        mpi::define_scope!(scope);
+        root_process
+            .immediate_scatter_varcount_into_root(scope, &partition, &mut buf[..])
+            .wait();
     } else {
-        mpi::request::scope(|scope| {
-            root_process
-                .immediate_scatter_varcount_into(scope, &mut buf[..])
-                .wait();
-        });
+        mpi::define_scope!(scope);
+
+        root_process
+            .immediate_scatter_varcount_into(scope, &mut buf[..])
+            .wait();
     }
 
     assert!(buf.iter().zip(0..rank).all(|(&i, j)| i == j));

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -14,35 +14,38 @@ fn main() {
     let previous_rank = if rank > 0 { rank - 1 } else { size - 1 };
 
     let msg = vec![rank, 2 * rank, 4 * rank];
-    mpi::request::scope(|scope| {
-        let _sreq = WaitGuard::from(
-            world
-                .process_at_rank(next_rank)
-                .immediate_send(scope, &msg[..]),
-        );
 
-        let (msg, status) = world.any_process().receive_vec();
+    // Defining scopes ensures that all borrowed buffers live until all requests
+    // that borrow them complete.
+    mpi::define_scope!(scope);
 
-        println!(
-            "Process {} got message {:?}.\nStatus is: {:?}",
-            rank, msg, status
-        );
-        let x = status.source_rank();
-        assert_eq!(x, previous_rank);
-        assert_eq!(vec![x, 2 * x, 4 * x], msg);
+    let _sreq = WaitGuard::from(
+        world
+            .process_at_rank(next_rank)
+            .immediate_send(scope, &msg[..]),
+    );
 
-        let root_rank = 0;
-        let root_process = world.process_at_rank(root_rank);
+    let (msg, status) = world.any_process().receive_vec();
 
-        let mut a;
-        if world.rank() == root_rank {
-            a = vec![2, 4, 8, 16];
-            println!("Root broadcasting value: {:?}.", &a[..]);
-        } else {
-            a = vec![0; 4];
-        }
-        root_process.broadcast_into(&mut a[..]);
-        println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
-        assert_eq!(&a[..], &[2, 4, 8, 16]);
-    });
+    println!(
+        "Process {} got message {:?}.\nStatus is: {:?}",
+        rank, msg, status
+    );
+    let x = status.source_rank();
+    assert_eq!(x, previous_rank);
+    assert_eq!(vec![x, 2 * x, 4 * x], msg);
+
+    let root_rank = 0;
+    let root_process = world.process_at_rank(root_rank);
+
+    let mut a;
+    if world.rank() == root_rank {
+        a = vec![2, 4, 8, 16];
+        println!("Root broadcasting value: {:?}.", &a[..]);
+    } else {
+        a = vec![0; 4];
+    }
+    root_process.broadcast_into(&mut a[..]);
+    println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
+    assert_eq!(&a[..], &[2, 4, 8, 16]);
 }

--- a/examples/ready_send.rs
+++ b/examples/ready_send.rs
@@ -16,7 +16,9 @@ fn main() {
         world.process_at_rank(0).ready_send(&msg);
     } else {
         let mut v = vec![0u8; (size - 1) as usize];
-        mpi::request::scope(|scope| {
+        {
+            mpi::define_scope!(scope);
+
             let reqs = v
                 .iter_mut()
                 .zip(1..)
@@ -30,7 +32,7 @@ fn main() {
             for req in reqs {
                 req.wait();
             }
-        });
+        }
         println!("Got message: {:?}", v);
         assert!(v.iter().zip(1..).all(|(x, i)| i == *x as usize));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ where
 #[macro_export]
 macro_rules! define_scope {
     ($name:ident) => {
-        let $name = $crate::request::LocalScope::new();
-        let $name = unsafe { ::std::pin::Pin::new_unchecked(&$name) };
+        let $name = unsafe { $crate::request::LocalScope::new() };
+        let $name = &$name;
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,3 +205,33 @@ where
         uninitialized2.assume_init(),
     )
 }
+
+/// Used to create a stack pinned [`LocalScope`](struct.LocalScope.html)
+///
+/// The macro creates a `LocalScope` on the stack, then shadows it with a `Pin` of the `LocalScope`,
+/// preventing the scope destructor from being skipped via `std::mem::forget` or similar.
+///
+/// For safety reasons, all variables and buffers associated with a request
+/// must exist *outside* the scope with which the request is registered.
+///
+/// It is typically used like this:
+///
+/// ```
+/// /* declare variables and buffers here ... */
+/// {
+///     mpi::define_scope!(scope);
+///     /* perform sends and/or receives using 'scope' */
+/// }
+/// /* at end of scope, panic if there are requests that have not yet completed */
+/// ```
+///
+/// # Examples
+///
+/// See `examples/immediate.rs`
+#[macro_export]
+macro_rules! define_scope {
+    ($name:ident) => {
+        let $name = $crate::request::LocalScope::new();
+        let $name = unsafe { ::std::pin::Pin::new_unchecked(&$name) };
+    };
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -28,9 +28,8 @@
 //!   - Cancellation, `MPI_Test_cancelled()`
 
 use std::cell::Cell;
-use std::marker::{PhantomData, PhantomPinned};
+use std::marker::PhantomData;
 use std::mem::{self, MaybeUninit};
-use std::pin::Pin;
 use std::ptr;
 
 use crate::ffi;
@@ -347,25 +346,18 @@ unsafe impl Scope<'static> for StaticScope {
 pub struct LocalScope<'a> {
     num_requests: Cell<usize>,
     phantom: PhantomData<Cell<&'a ()>>, // Cell needed to ensure 'a is invariant,
-    phantom_pinned: PhantomPinned,      // disables Unpin so that pinning is unsafe
 }
 
 impl<'a> LocalScope<'a> {
-    /// Constructs a `LocalScope`. Note that a `LocalScope` cannot be used for much on its own.
-    /// You'll need to `Pin` the scope first, which is an unsafe operation. Prefer using
-    /// [`mpi::request::scope`](fn.scope.html) or [`mpi::define_scope!`](macro.define_scope.html).
-    pub fn new() -> Self {
+    /// Creates a new `LocalScope`. The caller is responsible for ensuring the scope outlives all
+    /// `Request`s that are attached to it.
+    ///
+    /// Prefer `mpi::define_scope!` or `mpi::scope`.
+    pub unsafe fn new() -> Self {
         Self {
-            num_requests: Cell::new(0),
-            phantom: PhantomData,
-            phantom_pinned: PhantomPinned,
+            num_requests: Default::default(),
+            phantom: Default::default(),
         }
-    }
-
-    /// Constructs a `LocalScope` pinned in a `Box`. To use this scope, you must either pass it as
-    /// a reference or call `as_ref()` on it.
-    pub fn pinned() -> Pin<Box<LocalScope<'a>>> {
-        Box::new(LocalScope::new()).into()
     }
 }
 
@@ -377,7 +369,7 @@ impl<'a> Drop for LocalScope<'a> {
     }
 }
 
-unsafe impl<'a, 'b> Scope<'a> for Pin<&'b LocalScope<'a>> {
+unsafe impl<'a, 'b> Scope<'a> for &'b LocalScope<'a> {
     fn register(&self) {
         self.num_requests.set(self.num_requests.get() + 1)
     }
@@ -389,16 +381,6 @@ unsafe impl<'a, 'b> Scope<'a> for Pin<&'b LocalScope<'a>> {
                 .checked_sub(1)
                 .expect("unregister has been called more times than register"),
         )
-    }
-}
-
-unsafe impl<'a, 'b> Scope<'a> for &'b Pin<Box<LocalScope<'a>>> {
-    fn register(&self) {
-        self.as_ref().register()
-    }
-
-    unsafe fn unregister(&self) {
-        self.as_ref().unregister()
     }
 }
 
@@ -425,7 +407,7 @@ unsafe impl<'a, 'b> Scope<'a> for &'b Pin<Box<LocalScope<'a>>> {
 /// See `examples/immediate.rs`
 pub fn scope<'a, F, R>(f: F) -> R
 where
-    F: FnOnce(Pin<&LocalScope<'a>>) -> R,
+    F: FnOnce(&LocalScope<'a>) -> R,
 {
     crate::define_scope!(scope);
     f(scope)


### PR DESCRIPTION
The current mechanism for creating `LocalScope`s relies on a function and closures. This change adds a macro named `mpi::define_scope!` for defining the `LocalScope` instead, which allows the user to stay in their local function context, rather than having a separate function. This enables more rich flow control when dealing with scopes, and also unifies scope creation for when I add async support.

For example, `define_scope!` can be used like this:

```rust
// define send and receive buffers here
{
    // you may define send buffers here
    mpi::define_scope!(scope);
    // use scope like normal with receive and send buffers
}
// use receive buffers here
```

The macro works and is safe because the created `&LocalScope` shadows the stack-pinned `LocalScope`, making it impossible to forget, or even reference, the underlying `LocalScope`.

I also changed all the examples to use `mpi::define_scope!(scope);`.

There's probably a better name than `mpi::define_scope`, btw. Maybe just `mpi::scope!`? Or `mpi::request_scope!`?