### PR TITLE
Fix Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH="${HOME}/.local/bin:${MPI_PREFIX}/bin${PATH:+":${PATH}"}"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export LD_LIBRARY_PATH="${MPI_PREFIX}/lib${LD_LIBRARY_PATH:+":${LD_LIBRARY_PATH}"}"; fi
   # Windows set-up
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then rustup default $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then sh ci/install-mpi-windows.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export MSMPI_BIN="C:\\Program Files\\Microsoft MPI\\Bin\\"; fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then export MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"; fi


### PR DESCRIPTION
At some point Travis CI changed the default toolchain for Rust CI on Windows from x86_64-pc-windows-msvc to x86_64-pc-windows-gnu. Currently MS-MPI only seems to work with the MSVC toolchain, so explicitly set that as the default in the CI.