### PR TITLE
Update libffi, bindgen, and restore user-operations as a default feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,12 +96,9 @@ install:
     fi
 
 script:
-  - env RUSTFLAGS="--deny warnings" cargo build -v --no-default-features
-  # Don't build with default features on Windows
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then env RUSTFLAGS="--deny warnings" cargo build --all-features -v; fi
-  - if [ "$TRAVIS_OS_NAME" != "windows" ]; then env RUSTFLAGS="--deny warnings" cargo test --all --all-features -v; fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then env RUSTFLAGS="--deny warnings" cargo build -v --no-default-features --features derive; fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then env RUSTFLAGS="--deny warnings" cargo test --all -v --no-default-features --features derive; fi
+  - env RUSTFLAGS="--deny warnings" cargo build --no-default-features -v
+  - env RUSTFLAGS="--deny warnings" cargo build --all-features -v
+  - env RUSTFLAGS="--deny warnings" cargo test --all --all-features -v
   - env RUSTFLAGS="--deny warnings" sh ci/run-examples.sh
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       env RUSTFLAGS="--deny warnings" cargo clippy -v --all --examples --tests;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ derive = ["mpi-derive"]
 
 [dependencies]
 conv = "0.3"
-libffi = { version = "0.8.0", optional = true }
+libffi = { version = "1.0.0", optional = true }
 # Public dependency ("derive" feature)
 memoffset = "0.6"
 mpi-derive = { path = "mpi-derive", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ mpi-sys = { path = "mpi-sys", version = "0.2" }
 once_cell = "1.4"
 smallvec = "1.0.0"
 
+[build-dependencies]
+build-probe-mpi = { path = "build-probe-mpi", version = "0.1" }
+
 # The following tests depend on specific features
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 members = ["mpi-derive"]
 
 [features]
-default = []
+default = ["user-operations"]
 
 user-operations = ["libffi"]
 derive = ["mpi-derive"]

--- a/build-probe-mpi/src/os/windows.rs
+++ b/build-probe-mpi/src/os/windows.rs
@@ -22,9 +22,9 @@ pub fn probe() -> Result<Library, Vec<Box<dyn Error>>> {
         }
     };
 
-    let lib_env = if cfg!(target_arch = "i686") {
+    let lib_env = if env::var("CARGO_CFG_TARGET_ARCH") == Ok("x86".to_string()) {
         "MSMPI_LIB32"
-    } else if cfg!(target_arch = "x86_64") {
+    } else if env::var("CARGO_CFG_TARGET_ARCH") == Ok("x86_64".to_string()) {
         "MSMPI_LIB64"
     } else {
         panic!("rsmpi does not support your windows architecture!");
@@ -47,7 +47,7 @@ pub fn probe() -> Result<Library, Vec<Box<dyn Error>>> {
         libs: vec!["msmpi".to_owned()],
         lib_paths: vec![lib_path.map(PathBuf::from).unwrap()],
         include_paths: vec![include_path.map(PathBuf::from).unwrap()],
-        version: String::from("unknown"),
+        version: String::from("MS-MPI"),
         _priv: (),
     })
 }

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,7 @@
 use std::env::var;
 
 fn main() {
-    let is_msmpi = if let Ok(library) = build_probe_mpi::probe() {
-        if library.version == "MS-MPI" {
-            true
-        } else {
-            false
-        }
-    } else {
-        false
-    };
+    let is_msmpi = build_probe_mpi::probe().map_or(false, |lib| lib.version == "MS-MPI");
 
     if is_msmpi {
         println!("cargo:rustc-cfg=msmpi");

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,7 @@
-use std::env::var;
-
 fn main() {
     let is_msmpi = build_probe_mpi::probe().map_or(false, |lib| lib.version == "MS-MPI");
 
     if is_msmpi {
         println!("cargo:rustc-cfg=msmpi");
-
-        if var("CARGO_FEATURE_USER_OPERATIONS").is_ok()
-            && var("CARGO_CFG_TARGET_ARCH") == Ok("x86".to_string())
-        {
-            panic!(
-                "Feature 'user-operations' is not supported for MS-MPI on 32-bit Windows. \
-            See: https://github.com/rsmpi/rsmpi/issues/97"
-            )
-        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    let is_msmpi = build_probe_mpi::probe().map_or(false, |lib| lib.version == "MS-MPI");
+    let is_msmpi = match build_probe_mpi::probe() {
+        Ok(lib) => lib.version == "MS-MPI",
+        _ => false,
+    };
 
     if is_msmpi {
         println!("cargo:rustc-cfg=msmpi");

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,26 @@
+use std::env::var;
+
 fn main() {
-    if cfg!(windows) {
-        // Adds a cfg to identify MS-MPI. This should perhaps be a more robust check in the future.
+    let is_msmpi = if let Ok(library) = build_probe_mpi::probe() {
+        if library.version == "MS-MPI" {
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    if is_msmpi {
         println!("cargo:rustc-cfg=msmpi");
+
+        if var("CARGO_FEATURE_USER_OPERATIONS").is_ok()
+            && var("CARGO_CFG_TARGET_ARCH") == Ok("x86".to_string())
+        {
+            panic!(
+                "Feature 'user-operations' is not supported for MS-MPI on 32-bit Windows. \
+            See: https://github.com/rsmpi/rsmpi/issues/97"
+            )
+        }
     }
 }

--- a/examples/immediate_reduce.rs
+++ b/examples/immediate_reduce.rs
@@ -33,24 +33,7 @@ fn test_user_operations<C: Communicator>(comm: C) {
 #[cfg(not(feature = "user-operations"))]
 fn test_user_operations<C: Communicator>(_: C) {}
 
-#[cfg(not(msmpi))]
 unsafe extern "C" fn unsafe_add(
-    invec: *mut c_void,
-    inoutvec: *mut c_void,
-    len: *mut c_int,
-    _datatype: *mut MPI_Datatype,
-) {
-    use std::slice;
-
-    let x: &[Rank] = slice::from_raw_parts(invec as *const Rank, *len as usize);
-    let y: &mut [Rank] = slice::from_raw_parts_mut(inoutvec as *mut Rank, *len as usize);
-    for (&x_i, y_i) in x.iter().zip(y) {
-        *y_i += x_i;
-    }
-}
-
-#[cfg(msmpi)]
-unsafe extern "stdcall" fn unsafe_add(
     invec: *mut c_void,
     inoutvec: *mut c_void,
     len: *mut c_int,

--- a/examples/reduce.rs
+++ b/examples/reduce.rs
@@ -34,24 +34,7 @@ fn test_user_operations<C: Communicator>(comm: C) {
 #[cfg(not(feature = "user-operations"))]
 fn test_user_operations<C: Communicator>(_: C) {}
 
-#[cfg(not(msmpi))]
 unsafe extern "C" fn unsafe_add(
-    invec: *mut c_void,
-    inoutvec: *mut c_void,
-    len: *mut c_int,
-    _datatype: *mut MPI_Datatype,
-) {
-    use std::slice;
-
-    let x: &[Rank] = slice::from_raw_parts(invec as *const Rank, *len as usize);
-    let y: &mut [Rank] = slice::from_raw_parts_mut(inoutvec as *mut Rank, *len as usize);
-    for (&x_i, y_i) in x.iter().zip(y) {
-        *y_i += x_i;
-    }
-}
-
-#[cfg(msmpi)]
-unsafe extern "stdcall" fn unsafe_add(
     invec: *mut c_void,
     inoutvec: *mut c_void,
     len: *mut c_int,

--- a/examples/reduce.rs
+++ b/examples/reduce.rs
@@ -92,7 +92,7 @@ fn main() {
     let mut g: Rank = 0;
 
     world.reduce_scatter_block_into(&f[..], &mut g, SystemOperation::product());
-    assert_eq!(g, rank.pow(size as u32));
+    assert_eq!(g, rank.wrapping_pow(size as u32));
 
     test_user_operations(universe.world());
 

--- a/examples/reduce.rs
+++ b/examples/reduce.rs
@@ -34,7 +34,24 @@ fn test_user_operations<C: Communicator>(comm: C) {
 #[cfg(not(feature = "user-operations"))]
 fn test_user_operations<C: Communicator>(_: C) {}
 
+#[cfg(not(all(msmpi, target_arch = "x86")))]
 unsafe extern "C" fn unsafe_add(
+    invec: *mut c_void,
+    inoutvec: *mut c_void,
+    len: *mut c_int,
+    _datatype: *mut MPI_Datatype,
+) {
+    use std::slice;
+
+    let x: &[Rank] = slice::from_raw_parts(invec as *const Rank, *len as usize);
+    let y: &mut [Rank] = slice::from_raw_parts_mut(inoutvec as *mut Rank, *len as usize);
+    for (&x_i, y_i) in x.iter().zip(y) {
+        *y_i += x_i;
+    }
+}
+
+#[cfg(all(msmpi, target_arch = "x86"))]
+unsafe extern "stdcall" fn unsafe_add(
     invec: *mut c_void,
     inoutvec: *mut c_void,
     len: *mut c_int,

--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -17,5 +17,5 @@ license = "MIT/Apache-2.0"
 
 [build-dependencies]
 cc = "1.0.25"
-bindgen = "0.51"
+bindgen = "0.55"
 build-probe-mpi = { path = "../build-probe-mpi", version = "0.1" }

--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -21,25 +21,25 @@ fn main() {
         }
     };
 
-    // Use `mpicc` wrapper on Unix rather than the system C compiler.
+    let mut builder = cc::Build::new();
+    builder.file("src/rsmpi.c");
+
+    let compiler = builder.try_get_compiler();
+
     if cfg!(windows) {
-        let mut builder = cc::Build::new();
-
-        builder.file("src/rsmpi.c");
-
         for inc in &lib.include_paths {
             builder.include(inc);
         }
 
-        builder.compile("librsmpi.a");
-
         // Adds a cfg to identify MS-MPI
         println!("cargo:rustc-cfg=msmpi");
     } else {
+        // Use `mpicc` wrapper on Unix rather than the system C compiler.
         env::set_var("CC", "mpicc");
-        // Build the `rsmpi` C shim library.
-        cc::Build::new().file("src/rsmpi.c").compile("librsmpi.a");
     }
+
+    // Build the `rsmpi` C shim library.
+    builder.compile("rsmpi");
 
     // Let `rustc` know about the library search directories.
     for dir in &lib.lib_paths {
@@ -53,6 +53,22 @@ fn main() {
     // Let `bindgen` know about header search directories.
     for dir in &lib.include_paths {
         builder = builder.clang_arg(format!("-I{}", dir.display()));
+    }
+
+    // Get the same system includes as used to build the "rsmpi" lib. This block only really does
+    // anything when targeting msvc.
+    if let Ok(compiler) = compiler {
+        let include_env = compiler
+            .env()
+            .iter()
+            .filter(|(key, _)| key == "INCLUDE")
+            .next();
+        if let Some((_, include_paths)) = include_env {
+            if let Some(include_paths) = include_paths.to_str() {
+                // Add include paths via -I
+                builder = builder.clang_args(include_paths.split(";").map(|i| format!("-I{}", i)));
+            }
+        }
     }
 
     // Generate Rust bindings for the MPI C API.

--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -24,8 +24,6 @@ fn main() {
     let mut builder = cc::Build::new();
     builder.file("src/rsmpi.c");
 
-    let compiler = builder.try_get_compiler();
-
     if cfg!(windows) {
         for inc in &lib.include_paths {
             builder.include(inc);
@@ -35,8 +33,10 @@ fn main() {
         println!("cargo:rustc-cfg=msmpi");
     } else {
         // Use `mpicc` wrapper on Unix rather than the system C compiler.
-        env::set_var("CC", "mpicc");
+        builder.compiler("mpicc");
     }
+
+    let compiler = builder.try_get_compiler();
 
     // Build the `rsmpi` C shim library.
     builder.compile("rsmpi");

--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -58,11 +58,7 @@ fn main() {
     // Get the same system includes as used to build the "rsmpi" lib. This block only really does
     // anything when targeting msvc.
     if let Ok(compiler) = compiler {
-        let include_env = compiler
-            .env()
-            .iter()
-            .filter(|(key, _)| key == "INCLUDE")
-            .next();
+        let include_env = compiler.env().iter().find(|(key, _)| key == "INCLUDE");
         if let Some((_, include_paths)) = include_env {
             if let Some(include_paths) = include_paths.to_str() {
                 // Add include paths via -I

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1711,14 +1711,14 @@ impl<'a> UserOperation<'a> {
             ffi_closure: None,
         });
 
-        let args: smallvec::SmallVec<[Type; 4]> = smallvec::smallvec![
+        let args = [
             Type::pointer(), // void *
             Type::pointer(), // void *
             Type::pointer(), // int32_t *
             Type::pointer(), // MPI_Datatype *
         ];
         #[allow(unused_mut)]
-        let mut cif = Cif::new(args, Type::void());
+        let mut cif = Cif::new(args.iter().cloned(), Type::void());
         // MS-MPI uses "stdcall" calling convention on 32-bit x86
         #[cfg(all(msmpi, target_arch = "x86"))]
         cif.set_abi(libffi::raw::ffi_abi_FFI_STDCALL);

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1786,8 +1786,17 @@ unsafe impl AsRaw for UnsafeUserOperation {
 impl<'a> Operation for &'a UnsafeUserOperation {}
 
 /// A raw pointer to a function that can be used to define an `UnsafeUserOperation`.
+#[cfg(not(all(msmpi, target_arch = "x86")))]
 pub type UnsafeUserFunction =
     unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_int, *mut ffi::MPI_Datatype);
+
+/// A raw pointer to a function that can be used to define an `UnsafeUserOperation`.
+///
+/// MS-MPI uses "stdcall" rather than "C" calling convention. "stdcall" is ignored on x86_64
+/// Windows and the default calling convention is used instead.
+#[cfg(all(msmpi, target_arch = "x86"))]
+pub type UnsafeUserFunction =
+    unsafe extern "stdcall" fn(*mut c_void, *mut c_void, *mut c_int, *mut ffi::MPI_Datatype);
 
 impl UnsafeUserOperation {
     /// Define an unsafe operation using a function pointer. The operation must be associative.

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1698,7 +1698,7 @@ impl<'a> UserOperation<'a> {
             ffi_closure: None,
         });
 
-        let args = vec![
+        let args: smallvec::SmallVec<[Type; 4]> = smallvec::smallvec![
             Type::pointer(), // void *
             Type::pointer(), // void *
             Type::pointer(), // int32_t *


### PR DESCRIPTION
As of the "0.9.0" release of the libffi crate, Windows and Mac are now supported. Additionally, in "1.0.0", bindgen is no longer used by libffi, which means we can now update our version of the dependency.

In order to avoid surprising people with the "0.6" release, this makes "user-operations" a default feature again since it now has wider support.

Improved behavior in the "0.55" release of bindgen gets rid of the weird hacks that had to be done for MS-MPI.

cc @adamreichold @bsteinb 