### PR TITLE
Drop obsolete unsafe_extern_static macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,6 @@ mpi-sys = { path = "mpi-sys", version = "0.2" }
 once_cell = "1.4"
 smallvec = "1.0.0"
 
-[build-dependencies]
-rustc_version = "0.2"
-
 # The following tests depend on specific features
 
 [[example]]

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,4 @@
-extern crate rustc_version;
-use rustc_version::Version as RustcVersion;
-
 fn main() {
-    // Access to extern statics has to be marked unsafe after 1.13.0
-    if rustc_version::version().unwrap() >= RustcVersion::parse("1.13.0").unwrap() {
-        println!("cargo:rustc-cfg=extern_statics_are_unsafe");
-    }
-
     if cfg!(windows) {
         // Adds a cfg to identify MS-MPI. This should perhaps be a more robust check in the future.
         println!("cargo:rustc-cfg=msmpi");

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1559,7 +1559,7 @@ macro_rules! system_operation_constructors {
     ($($ctor:ident => $val:path),*) => (
         $(pub fn $ctor() -> SystemOperation {
             //! A built-in operation
-            SystemOperation(unsafe_extern_static!($val))
+            SystemOperation(unsafe { $val })
         })*
     )
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -380,7 +380,7 @@ impl Drop for UserDatatype {
         unsafe {
             ffi::MPI_Type_free(&mut self.0);
         }
-        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_DATATYPE_NULL));
+        assert_eq!(self.0, unsafe { ffi::RSMPI_DATATYPE_NULL });
     }
 }
 
@@ -696,7 +696,7 @@ impl Drop for UncommittedUserDatatype {
         unsafe {
             ffi::MPI_Type_free(&mut self.0);
         }
-        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_DATATYPE_NULL));
+        assert_eq!(self.0, unsafe { ffi::RSMPI_DATATYPE_NULL });
     }
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -138,10 +138,10 @@ impl Threading {
     fn as_raw(self) -> c_int {
         use self::Threading::*;
         match self {
-            Single => unsafe_extern_static!(ffi::RSMPI_THREAD_SINGLE),
-            Funneled => unsafe_extern_static!(ffi::RSMPI_THREAD_FUNNELED),
-            Serialized => unsafe_extern_static!(ffi::RSMPI_THREAD_SERIALIZED),
-            Multiple => unsafe_extern_static!(ffi::RSMPI_THREAD_MULTIPLE),
+            Single => unsafe { ffi::RSMPI_THREAD_SINGLE },
+            Funneled => unsafe { ffi::RSMPI_THREAD_FUNNELED },
+            Serialized => unsafe { ffi::RSMPI_THREAD_SERIALIZED },
+            Multiple => unsafe { ffi::RSMPI_THREAD_MULTIPLE },
         }
     }
 }
@@ -161,13 +161,13 @@ impl Ord for Threading {
 impl From<c_int> for Threading {
     fn from(i: c_int) -> Threading {
         use self::Threading::*;
-        if i == unsafe_extern_static!(ffi::RSMPI_THREAD_SINGLE) {
+        if i == unsafe { ffi::RSMPI_THREAD_SINGLE } {
             return Single;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_FUNNELED) {
+        } else if i == unsafe { ffi::RSMPI_THREAD_FUNNELED } {
             return Funneled;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_SERIALIZED) {
+        } else if i == unsafe { ffi::RSMPI_THREAD_SERIALIZED } {
             return Serialized;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_THREAD_MULTIPLE) {
+        } else if i == unsafe { ffi::RSMPI_THREAD_MULTIPLE } {
             return Multiple;
         }
         panic!("Unknown threading level: {}", i)
@@ -281,12 +281,12 @@ pub fn version() -> (c_int, c_int) {
 ///
 /// Can be called without initializing MPI.
 pub fn library_version() -> Result<String, FromUtf8Error> {
-    let bufsize = unsafe_extern_static!(ffi::RSMPI_MAX_LIBRARY_VERSION_STRING)
+    let bufsize = unsafe { ffi::RSMPI_MAX_LIBRARY_VERSION_STRING }
         .value_as()
         .unwrap_or_else(|_| {
             panic!(
                 "MPI_MAX_LIBRARY_SIZE ({}) cannot be expressed as a usize.",
-                unsafe_extern_static!(ffi::RSMPI_MAX_LIBRARY_VERSION_STRING)
+                unsafe { ffi::RSMPI_MAX_LIBRARY_VERSION_STRING }
             )
         });
     let mut buf = vec![0u8; bufsize];
@@ -309,14 +309,14 @@ pub fn library_version() -> Result<String, FromUtf8Error> {
 ///
 /// Can return an `Err` if the processor name is not a UTF-8 string.
 pub fn processor_name() -> Result<String, FromUtf8Error> {
-    let bufsize = unsafe_extern_static!(ffi::RSMPI_MAX_PROCESSOR_NAME)
+    let bufsize = unsafe { ffi::RSMPI_MAX_PROCESSOR_NAME }
         .value_as()
         .unwrap_or_else(|_| {
             panic!(
                 "MPI_MAX_LIBRARY_SIZE ({}) \
                  cannot be expressed as a \
                  usize.",
-                unsafe_extern_static!(ffi::RSMPI_MAX_PROCESSOR_NAME)
+                unsafe { ffi::RSMPI_MAX_PROCESSOR_NAME }
             )
         });
     let mut buf = vec![0u8; bufsize];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,20 +130,6 @@ use std::os::raw::c_int;
 #[macro_use]
 pub mod ffi {
     pub use mpi_sys::*;
-
-    #[cfg(extern_statics_are_unsafe)]
-    macro_rules! unsafe_extern_static {
-        ( $x:expr ) => {
-            unsafe { $x }
-        };
-    }
-
-    #[cfg(not(extern_statics_are_unsafe))]
-    macro_rules! unsafe_extern_static {
-        ( $x:expr ) => {
-            $x
-        };
-    }
 }
 
 pub mod collective;

--- a/src/point_to_point.rs
+++ b/src/point_to_point.rs
@@ -92,7 +92,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.1
     fn probe(&self) -> Status {
-        self.probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.probe_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Probe a source for incoming messages with guaranteed reception.
@@ -133,7 +133,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.2
     fn matched_probe(&self) -> (Message, Status) {
-        self.matched_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.matched_probe_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Receive a message containing a single instance of type `Msg`.
@@ -190,7 +190,7 @@ pub unsafe trait Source: AsCommunicator {
     where
         Msg: Equivalence,
     {
-        self.receive_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.receive_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Receive a message into a `Buffer`.
@@ -233,7 +233,7 @@ pub unsafe trait Source: AsCommunicator {
     where
         Buf: BufferMut,
     {
-        self.receive_into_with_tag(buf, unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.receive_into_with_tag(buf, unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Receive a message containing multiple instances of type `Msg` into a `Vec`.
@@ -266,7 +266,7 @@ pub unsafe trait Source: AsCommunicator {
     where
         Msg: Equivalence,
     {
-        self.receive_vec_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.receive_vec_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Initiate an immediate (non-blocking) receive operation.
@@ -324,7 +324,7 @@ pub unsafe trait Source: AsCommunicator {
         Buf: 'a + BufferMut,
         Sc: Scope<'a>,
     {
-        self.immediate_receive_into_with_tag(scope, buf, unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.immediate_receive_into_with_tag(scope, buf, unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Initiate a non-blocking receive operation for messages matching tag `tag`.
@@ -368,7 +368,7 @@ pub unsafe trait Source: AsCommunicator {
     where
         Msg: Equivalence,
     {
-        self.immediate_receive_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.immediate_receive_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Asynchronously probe a source for incoming messages.
@@ -412,7 +412,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.1
     fn immediate_probe(&self) -> Option<Status> {
-        self.immediate_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.immediate_probe_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 
     /// Asynchronously probe a source for incoming messages with guaranteed reception.
@@ -460,7 +460,7 @@ pub unsafe trait Source: AsCommunicator {
     ///
     /// 3.8.2
     fn immediate_matched_probe(&self) -> Option<(Message, Status)> {
-        self.immediate_matched_probe_with_tag(unsafe_extern_static!(ffi::RSMPI_ANY_TAG))
+        self.immediate_matched_probe_with_tag(unsafe { ffi::RSMPI_ANY_TAG })
     }
 }
 
@@ -469,7 +469,7 @@ where
     C: 'a + Communicator,
 {
     fn source_rank(&self) -> Rank {
-        unsafe_extern_static!(ffi::RSMPI_ANY_SOURCE)
+        unsafe { ffi::RSMPI_ANY_SOURCE }
     }
 }
 
@@ -945,7 +945,7 @@ pub struct Message(MPI_Message);
 impl Message {
     /// True if the `Source` for the probe was the null process.
     pub fn is_no_proc(&self) -> bool {
-        self.as_raw() == unsafe_extern_static!(ffi::RSMPI_MESSAGE_NO_PROC)
+        self.as_raw() == unsafe { ffi::RSMPI_MESSAGE_NO_PROC }
     }
 
     /// Receive a previously probed message containing a single instance of type `Msg`.
@@ -1055,7 +1055,7 @@ impl Drop for Message {
     fn drop(&mut self) {
         assert_eq!(
             self.as_raw(),
-            unsafe_extern_static!(ffi::RSMPI_MESSAGE_NULL),
+            unsafe { ffi::RSMPI_MESSAGE_NULL },
             "matched message dropped without receiving."
         );
     }
@@ -1170,13 +1170,9 @@ where
     R: Equivalence,
     S: Source,
 {
-    send_receive_with_tags(
-        msg,
-        destination,
-        Tag::default(),
-        source,
-        unsafe_extern_static!(ffi::RSMPI_ANY_TAG),
-    )
+    send_receive_with_tags(msg, destination, Tag::default(), source, unsafe {
+        ffi::RSMPI_ANY_TAG
+    })
 }
 
 /// Sends the contents of `msg` to `destination` tagging it `sendtag` and
@@ -1248,14 +1244,9 @@ where
     B: BufferMut,
     S: Source,
 {
-    send_receive_into_with_tags(
-        msg,
-        destination,
-        Tag::default(),
-        buf,
-        source,
-        unsafe_extern_static!(ffi::RSMPI_ANY_TAG),
-    )
+    send_receive_into_with_tags(msg, destination, Tag::default(), buf, source, unsafe {
+        ffi::RSMPI_ANY_TAG
+    })
 }
 
 /// Sends the contents of `buf` to `destination` tagging it `sendtag` and
@@ -1320,13 +1311,9 @@ where
     D: Destination,
     S: Source,
 {
-    send_receive_replace_into_with_tags(
-        buf,
-        destination,
-        Tag::default(),
-        source,
-        unsafe_extern_static!(ffi::RSMPI_ANY_TAG),
-    )
+    send_receive_replace_into_with_tags(buf, destination, Tag::default(), source, unsafe {
+        ffi::RSMPI_ANY_TAG
+    })
 }
 
 /// Will contain a value of type `T` received via a non-blocking receive operation.

--- a/src/request.rs
+++ b/src/request.rs
@@ -42,7 +42,7 @@ use crate::with_uninitialized;
 
 /// Check if the request is `MPI_REQUEST_NULL`.
 fn is_null(request: MPI_Request) -> bool {
-    request == unsafe_extern_static!(ffi::RSMPI_REQUEST_NULL)
+    request == unsafe { ffi::RSMPI_REQUEST_NULL }
 }
 
 /// A request object for a non-blocking operation registered with a `Scope` of lifetime `'a`

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -73,13 +73,13 @@ impl SystemCommunicator {
     /// # Examples
     /// See `examples/simple.rs`
     pub fn world() -> SystemCommunicator {
-        SystemCommunicator::from_raw_unchecked(unsafe_extern_static!(ffi::RSMPI_COMM_WORLD))
+        SystemCommunicator::from_raw_unchecked(unsafe { ffi::RSMPI_COMM_WORLD })
     }
 
     /// If the raw value is the null handle returns `None`
     #[allow(dead_code)]
     fn from_raw(raw: MPI_Comm) -> Option<SystemCommunicator> {
-        if raw == unsafe_extern_static!(ffi::RSMPI_COMM_NULL) {
+        if raw == unsafe { ffi::RSMPI_COMM_NULL } {
             None
         } else {
             Some(SystemCommunicator(raw))
@@ -88,7 +88,7 @@ impl SystemCommunicator {
 
     /// Wraps the raw value without checking for null handle
     fn from_raw_unchecked(raw: MPI_Comm) -> SystemCommunicator {
-        debug_assert_ne!(raw, unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
+        debug_assert_ne!(raw, unsafe { ffi::RSMPI_COMM_NULL });
         SystemCommunicator(raw)
     }
 }
@@ -153,7 +153,7 @@ impl UserCommunicator {
 
     /// Wraps the raw value without checking for null handle
     fn from_raw_unchecked(raw: MPI_Comm) -> UserCommunicator {
-        debug_assert_ne!(raw, unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
+        debug_assert_ne!(raw, unsafe { ffi::RSMPI_COMM_NULL });
         UserCommunicator(raw)
     }
 
@@ -215,7 +215,7 @@ impl Drop for UserCommunicator {
         unsafe {
             ffi::MPI_Comm_free(&mut self.0);
         }
-        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_COMM_NULL));
+        assert_eq!(self.0, unsafe { ffi::RSMPI_COMM_NULL });
     }
 }
 
@@ -240,7 +240,7 @@ pub struct Color(c_int);
 impl Color {
     /// Special color of undefined value
     pub fn undefined() -> Color {
-        Color(unsafe_extern_static!(ffi::RSMPI_UNDEFINED))
+        Color(unsafe { ffi::RSMPI_UNDEFINED })
     }
 
     /// A color of a certain value
@@ -746,13 +746,13 @@ impl From<c_int> for CommunicatorRelation {
     fn from(i: c_int) -> CommunicatorRelation {
         use self::CommunicatorRelation::*;
         // FIXME: Yuck! These should be made const.
-        if i == unsafe_extern_static!(ffi::RSMPI_IDENT) {
+        if i == unsafe { ffi::RSMPI_IDENT } {
             return Identical;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_CONGRUENT) {
+        } else if i == unsafe { ffi::RSMPI_CONGRUENT } {
             return Congruent;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_SIMILAR) {
+        } else if i == unsafe { ffi::RSMPI_SIMILAR } {
             return Similar;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_UNEQUAL) {
+        } else if i == unsafe { ffi::RSMPI_UNEQUAL } {
             return Unequal;
         }
         panic!("Unknown communicator relation: {}", i)
@@ -775,7 +775,7 @@ where
 {
     #[allow(dead_code)]
     fn by_rank(c: &'a C, r: Rank) -> Option<Self> {
-        if r != unsafe_extern_static!(ffi::RSMPI_PROC_NULL) {
+        if r != unsafe { ffi::RSMPI_PROC_NULL } {
             Some(Process { comm: c, rank: r })
         } else {
             None
@@ -829,7 +829,7 @@ pub struct SystemGroup(MPI_Group);
 impl SystemGroup {
     /// An empty group
     pub fn empty() -> SystemGroup {
-        SystemGroup(unsafe_extern_static!(ffi::RSMPI_GROUP_EMPTY))
+        SystemGroup(unsafe { ffi::RSMPI_GROUP_EMPTY })
     }
 }
 
@@ -854,7 +854,7 @@ impl Drop for UserGroup {
         unsafe {
             ffi::MPI_Group_free(&mut self.0);
         }
-        assert_eq!(self.0, unsafe_extern_static!(ffi::RSMPI_GROUP_NULL));
+        assert_eq!(self.0, unsafe { ffi::RSMPI_GROUP_NULL });
     }
 }
 
@@ -1076,11 +1076,11 @@ impl From<c_int> for GroupRelation {
     fn from(i: c_int) -> GroupRelation {
         use self::GroupRelation::*;
         // FIXME: Yuck! These should be made const.
-        if i == unsafe_extern_static!(ffi::RSMPI_IDENT) {
+        if i == unsafe { ffi::RSMPI_IDENT } {
             return Identical;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_SIMILAR) {
+        } else if i == unsafe { ffi::RSMPI_SIMILAR } {
             return Similar;
-        } else if i == unsafe_extern_static!(ffi::RSMPI_UNEQUAL) {
+        } else if i == unsafe { ffi::RSMPI_UNEQUAL } {
             return Unequal;
         }
         panic!("Unknown group relation: {}", i)


### PR DESCRIPTION
This was created using regex-based mass-replacement of the now obsolete `unsafe_extern_static` macro.