### PR TITLE
Fix derive Equivalence for arrays + formatting

### DIFF
--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -79,7 +79,7 @@ fn main() {
     struct MyDataOrdered {
         bf: (bool, f64),
         i: u16,
-    };
+    }
 
     assert_equivalence(
         &world,
@@ -97,7 +97,7 @@ fn main() {
     #[derive(Equivalence, Default, PartialEq, Debug)]
     struct MyDataNestedTuple {
         bfi: (bool, (f64, u16)),
-    };
+    }
 
     assert_equivalence(
         &world,

--- a/mpi-derive/src/lib.rs
+++ b/mpi-derive/src/lib.rs
@@ -43,7 +43,7 @@ fn equivalence_for_tuple_field(type_tuple: &syn::TypeTuple) -> TokenStream2 {
 fn equivalence_for_array_field(type_array: &syn::TypeArray) -> TokenStream2 {
     let ty = equivalence_for_type(&type_array.elem);
     let len = &type_array.len;
-    quote! { &::mpi::datatype::UncommittedUserDatatype::contiguous(#len, &#ty) }
+    quote! { &::mpi::datatype::UncommittedUserDatatype::contiguous(#len as i32, &#ty) }
 }
 
 fn equivalence_for_type(ty: &syn::Type) -> TokenStream2 {

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1687,13 +1687,13 @@ impl<'a> UserOperation<'a> {
     {
         struct ClosureAnchor<F> {
             rust_closure: F,
-            ffi_closure: Option<Closure<'static>>,
+            _ffi_closure: Option<Closure<'static>>,
         }
 
         // must box it to prevent moves
         let mut anchor = Box::new(ClosureAnchor {
             rust_closure: function,
-            ffi_closure: None,
+            _ffi_closure: None,
         });
 
         let args = [
@@ -1738,7 +1738,7 @@ impl<'a> UserOperation<'a> {
         }
 
         let op;
-        anchor.ffi_closure = Some(unsafe {
+        anchor._ffi_closure = Some(unsafe {
             let ffi_closure = Closure::new(cif, trampoline, &anchor.rust_closure);
             op = with_uninitialized(|op| {
                 ffi::MPI_Op_create(Some(*ffi_closure.instantiate_code_ptr()), commute as _, op)

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,14 +1,20 @@
 #![cfg(feature = "derive")]
 
 use mpi::traits::Equivalence;
-const CONSTANT: usize = 7;
 
 /// We test that #[derive(Equivalence)] correctly casts CONSTANT to a i32 for the
 /// C interop. For defining a rust array, CONSTANT must be usize.
 #[test]
 fn derive_equivalence() {
+    const CONSTANT: usize = 7;
     #[derive(Equivalence)]
     struct ArrayWrapper {
+        // Size is a variable
         field: [f32; CONSTANT],
+    }
+    #[derive(Equivalence)]
+    struct ArrayWrapper2 {
+        // Size is a {number}
+        field: [usize; 7],
     }
 }

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "derive")]
+
+use mpi::traits::Equivalence;
+const CONSTANT: usize = 7;
+
+/// We test that #[derive(Equivalence)] correctly casts CONSTANT to a i32 for the
+/// C interop. For defining a rust array, CONSTANT must be usize.
+#[test]
+fn derive_equivalence() {
+    #[derive(Equivalence)]
+    struct ArrayWrapper {
+        field: [f32; CONSTANT],
+    }
+}


### PR DESCRIPTION
Allows the derive macro to be used on static arrays with non `{integer}`
type constants, Specifically, `usize`. I include a test to prevent
regression.

I made 2 cosmetic changes in collective.rs and examples/struct.rs to
allow `rsmpi` to compile without warnings.