### PR TITLE
Implement Buffer and BufferMut for Vec

### DIFF
--- a/examples/broadcast.rs
+++ b/examples/broadcast.rs
@@ -29,7 +29,7 @@ fn main() {
     } else {
         a = std::iter::repeat(0_u64).take(n).collect::<Vec<_>>();
     }
-    root_process.broadcast_into(&mut a[..]);
+    root_process.broadcast_into(&mut a);
     println!("Rank {} received value: {:?}.", world.rank(), &a[..]);
     assert_eq!(&a[..], &[2, 4, 8, 16]);
 }

--- a/examples/scatter.rs
+++ b/examples/scatter.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut x = 0 as Rank;
     if rank == root_rank {
         let v = (0..size).collect::<Vec<_>>();
-        root_process.scatter_into_root(&v[..], &mut x);
+        root_process.scatter_into_root(&v, &mut x);
     } else {
         root_process.scatter_into(&mut x);
     }

--- a/examples/send_receive.rs
+++ b/examples/send_receive.rs
@@ -25,8 +25,8 @@ fn main() {
     assert_eq!(msg, next_rank);
 
     if rank > 0 {
-        let msg = vec![rank, rank + 1, rank - 1];
-        world.process_at_rank(0).send(&msg[..]);
+        let msg: [Rank; 3] = [rank, rank + 1, rank - 1];
+        world.process_at_rank(0).send(&msg);
     } else {
         for _ in 1..size {
             let (msg, status) = world.any_process().receive_vec::<Rank>();

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -798,6 +798,16 @@ where
     }
 }
 
+unsafe impl<T, const D: usize> AsDatatype for [T; D]
+where
+    T: Equivalence,
+{
+    type Out = <T as Equivalence>::Out;
+    fn as_datatype(&self) -> Self::Out {
+        <T as Equivalence>::equivalent_datatype()
+    }
+}
+
 #[doc(hidden)]
 pub mod internal {
     #[cfg(feature = "derive")]
@@ -890,6 +900,17 @@ where
     }
 }
 
+unsafe impl<T, const D: usize> Collection for [T; D]
+where
+    T: Equivalence,
+{
+    fn count(&self) -> Count {
+        // TODO const generic bound
+        D.value_as()
+            .expect("Length of slice cannot be expressed as an MPI Count.")
+    }
+}
+
 /// Provides a pointer to the starting address in memory.
 pub unsafe trait Pointer {
     /// A pointer to the starting address in memory
@@ -916,6 +937,15 @@ where
 }
 
 unsafe impl<T> Pointer for Vec<T>
+where
+    T: Equivalence,
+{
+    fn pointer(&self) -> *const c_void {
+        self.as_ptr() as _
+    }
+}
+
+unsafe impl<T, const D: usize> Pointer for [T; D]
 where
     T: Equivalence,
 {
@@ -958,12 +988,22 @@ where
     }
 }
 
+unsafe impl<T, const D: usize> PointerMut for [T; D]
+where
+    T: Equivalence,
+{
+    fn pointer_mut(&mut self) -> *mut c_void {
+        self.as_mut_ptr() as _
+    }
+}
+
 /// A buffer is a region in memory that starts at `pointer()` and contains `count()` copies of
 /// `as_datatype()`.
 pub unsafe trait Buffer: Pointer + Collection + AsDatatype {}
 unsafe impl<T> Buffer for T where T: Equivalence {}
 unsafe impl<T> Buffer for [T] where T: Equivalence {}
 unsafe impl<T> Buffer for Vec<T> where T: Equivalence {}
+unsafe impl<T, const D: usize> Buffer for [T; D] where T: Equivalence {}
 
 /// A mutable buffer is a region in memory that starts at `pointer_mut()` and contains `count()`
 /// copies of `as_datatype()`.
@@ -971,6 +1011,7 @@ pub unsafe trait BufferMut: PointerMut + Collection + AsDatatype {}
 unsafe impl<T> BufferMut for T where T: Equivalence {}
 unsafe impl<T> BufferMut for [T] where T: Equivalence {}
 unsafe impl<T> BufferMut for Vec<T> where T: Equivalence {}
+unsafe impl<T, const D: usize> BufferMut for [T; D] where T: Equivalence {}
 
 /// An immutable dynamically-typed buffer.
 ///

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -788,6 +788,16 @@ where
     }
 }
 
+unsafe impl<T> AsDatatype for Vec<T>
+where
+    T: Equivalence,
+{
+    type Out = <T as Equivalence>::Out;
+    fn as_datatype(&self) -> Self::Out {
+        <T as Equivalence>::equivalent_datatype()
+    }
+}
+
 #[doc(hidden)]
 pub mod internal {
     #[cfg(feature = "derive")]
@@ -869,6 +879,17 @@ where
     }
 }
 
+unsafe impl<T> Collection for Vec<T>
+where
+    T: Equivalence,
+{
+    fn count(&self) -> Count {
+        self.len()
+            .value_as()
+            .expect("Length of slice cannot be expressed as an MPI Count.")
+    }
+}
+
 /// Provides a pointer to the starting address in memory.
 pub unsafe trait Pointer {
     /// A pointer to the starting address in memory
@@ -886,6 +907,15 @@ where
 }
 
 unsafe impl<T> Pointer for [T]
+where
+    T: Equivalence,
+{
+    fn pointer(&self) -> *const c_void {
+        self.as_ptr() as _
+    }
+}
+
+unsafe impl<T> Pointer for Vec<T>
 where
     T: Equivalence,
 {
@@ -919,17 +949,28 @@ where
     }
 }
 
+unsafe impl<T> PointerMut for Vec<T>
+where
+    T: Equivalence,
+{
+    fn pointer_mut(&mut self) -> *mut c_void {
+        self.as_mut_ptr() as _
+    }
+}
+
 /// A buffer is a region in memory that starts at `pointer()` and contains `count()` copies of
 /// `as_datatype()`.
 pub unsafe trait Buffer: Pointer + Collection + AsDatatype {}
 unsafe impl<T> Buffer for T where T: Equivalence {}
 unsafe impl<T> Buffer for [T] where T: Equivalence {}
+unsafe impl<T> Buffer for Vec<T> where T: Equivalence {}
 
 /// A mutable buffer is a region in memory that starts at `pointer_mut()` and contains `count()`
 /// copies of `as_datatype()`.
 pub unsafe trait BufferMut: PointerMut + Collection + AsDatatype {}
 unsafe impl<T> BufferMut for T where T: Equivalence {}
 unsafe impl<T> BufferMut for [T] where T: Equivalence {}
+unsafe impl<T> BufferMut for Vec<T> where T: Equivalence {}
 
 /// An immutable dynamically-typed buffer.
 ///


### PR DESCRIPTION
To allow `&vec` instead of `vec.as_slice()`.