### PR TITLE
impl equivalence for complex numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ mpi-sys = { path = "mpi-sys", version = "0.2" }
 # Public dependency ("derive" feature)
 once_cell = "1.4"
 smallvec = "1.0.0"
+num-complex = "0.4"
 
 [build-dependencies]
 build-probe-mpi = { path = "build-probe-mpi", version = "0.1" }

--- a/examples/broadcast_complex.rs
+++ b/examples/broadcast_complex.rs
@@ -1,0 +1,35 @@
+/// Broadcast complex valued data
+extern crate mpi;
+use mpi::traits::*;
+use num_complex::Complex;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let root_process = world.process_at_rank(0);
+
+    let mut data = if world.rank() == 0 {
+        [
+            Complex::<f64>::new(1., -2.),
+            Complex::<f64>::new(8., -4.),
+            Complex::<f64>::new(3., -9.),
+            Complex::<f64>::new(7., -5.),
+        ]
+    } else {
+        [Complex::<f64>::new(0., 0.); 4]
+    };
+
+    // root_process.broadcast_into(&mut data);
+    root_process.broadcast_into(&mut data[..]);
+
+    assert_eq!(
+        data,
+        [
+            Complex::<f64>::new(1., -2.),
+            Complex::<f64>::new(8., -4.),
+            Complex::<f64>::new(3., -9.),
+            Complex::<f64>::new(7., -5.),
+        ]
+    );
+}

--- a/mpi-sys/src/rsmpi.c
+++ b/mpi-sys/src/rsmpi.c
@@ -5,6 +5,9 @@ const MPI_Datatype RSMPI_C_BOOL = MPI_C_BOOL;
 const MPI_Datatype RSMPI_FLOAT = MPI_FLOAT;
 const MPI_Datatype RSMPI_DOUBLE = MPI_DOUBLE;
 
+const MPI_Datatype RSMPI_COMPLEX = MPI_COMPLEX;
+const MPI_Datatype RSMPI_DOUBLE_COMPLEX = MPI_DOUBLE_COMPLEX;
+
 const MPI_Datatype RSMPI_INT8_T = MPI_INT8_T;
 const MPI_Datatype RSMPI_INT16_T = MPI_INT16_T;
 const MPI_Datatype RSMPI_INT32_T = MPI_INT32_T;

--- a/mpi-sys/src/rsmpi.h
+++ b/mpi-sys/src/rsmpi.h
@@ -11,6 +11,9 @@ extern const MPI_Datatype RSMPI_C_BOOL;
 extern const MPI_Datatype RSMPI_FLOAT;
 extern const MPI_Datatype RSMPI_DOUBLE;
 
+extern const MPI_Datatype RSMPI_COMPLEX;
+extern const MPI_Datatype RSMPI_DOUBLE_COMPLEX;
+
 extern const MPI_Datatype RSMPI_INT8_T;
 extern const MPI_Datatype RSMPI_INT16_T;
 extern const MPI_Datatype RSMPI_INT32_T;

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -70,6 +70,8 @@ use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::{mem, slice};
 
+use num_complex::Complex;
+
 use conv::ConvUtil;
 
 use super::{Address, Count};
@@ -192,6 +194,9 @@ equivalent_system_datatype!(bool, ffi::RSMPI_C_BOOL);
 
 equivalent_system_datatype!(f32, ffi::RSMPI_FLOAT);
 equivalent_system_datatype!(f64, ffi::RSMPI_DOUBLE);
+
+equivalent_system_datatype!(Complex<f32>, ffi::RSMPI_COMPLEX);
+equivalent_system_datatype!(Complex<f64>, ffi::RSMPI_DOUBLE_COMPLEX);
 
 equivalent_system_datatype!(i8, ffi::RSMPI_INT8_T);
 equivalent_system_datatype!(i16, ffi::RSMPI_INT16_T);


### PR DESCRIPTION
Hi,

what about adding support for complex numbers?

The corresponding MPI data types are readily available for float and double, thus the implementation is straightforward.
The only drawback I see is that it adds an additional dependency (num_complex).

Best regards