### PR TITLE
Improve pkg-config detection and support Cray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ authors = [
     "Andrew Gaspar <andrew.gaspar@outlook.com>"
 ]
 description = "Message Passing Interface bindings for Rust"
-homepage = "https://github.com/bsteinb/rsmpi"
-repository = "https://github.com/bsteinb/rsmpi"
-documentation = "http://bsteinb.github.io/rsmpi/"
+homepage = "https://github.com/rsmpi/rsmpi"
+repository = "https://github.com/rsmpi/rsmpi"
+documentation = "https://rsmpi.github.io/rsmpi/"
 readme = "README.md"
 keywords = [ "message-passing", "parallel" ]
 categories = [ "concurrency" ]

--- a/build-probe-mpi/Cargo.toml
+++ b/build-probe-mpi/Cargo.toml
@@ -6,8 +6,8 @@ authors = [
     "Andrew Gaspar <andrew.gaspar@outlook.com>"
 ]
 description = "Probes the system for an installation of an MPI library"
-homepage = "https://github.com/bsteinb/rsmpi"
-repository = "https://github.com/bsteinb/rsmpi"
+homepage = "https://github.com/rsmpi/rsmpi"
+repository = "https://github.com/rsmpi/rsmpi"
 categories = [ "development-tools::build-utils" ]
 license = "MIT/Apache-2.0"
 

--- a/build-probe-mpi/src/lib.rs
+++ b/build-probe-mpi/src/lib.rs
@@ -36,6 +36,8 @@ use std::path::PathBuf;
 #[allow(clippy::manual_non_exhaustive)]
 #[derive(Clone, Debug)]
 pub struct Library {
+    /// Path to compiler capable of building MPI programs
+    pub mpicc: Option<String>,
     /// Names of the native MPI libraries that need to be linked
     pub libs: Vec<String>,
     /// Search path for native MPI libraries

--- a/build-probe-mpi/src/os/windows.rs
+++ b/build-probe-mpi/src/os/windows.rs
@@ -67,6 +67,7 @@ pub fn probe() -> Result<Library, Vec<Box<dyn Error>>> {
     }
 
     Ok(Library {
+        mpicc: None,
         libs: vec!["msmpi".to_owned()],
         lib_paths: vec![lib_path.map(PathBuf::from).unwrap()],
         include_paths: vec![include_path.map(PathBuf::from).unwrap()],

--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -6,9 +6,9 @@ authors = [
     "Andrew Gaspar <andrew.gaspar@outlook.com>"
 ]
 description = "Message Passing Interface bindings for Rust"
-homepage = "https://github.com/bsteinb/rsmpi"
-repository = "https://github.com/bsteinb/rsmpi"
-documentation = "http://bsteinb.github.io/rsmpi/"
+homepage = "https://github.com/rsmpi/rsmpi"
+repository = "https://github.com/rsmpi/rsmpi"
+documentation = "https://rsmpi.github.io/rsmpi/"
 keywords = [ "message-passing", "parallel" ]
 categories = [ "external-ffi-bindings" ]
 license = "MIT/Apache-2.0"

--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -25,15 +25,17 @@ fn main() {
     builder.file("src/rsmpi.c");
 
     if cfg!(windows) {
+        // Adds a cfg to identify MS-MPI
+        println!("cargo:rustc-cfg=msmpi");
+    }
+    if let Some(mpicc) = lib.mpicc {
+        // Use `mpicc` wrapper when it exists rather than the system C compiler.
+        builder.compiler(mpicc);
+    } else {
+        // Specify paths (e.g., from pkg-config) when we don't have mpicc
         for inc in &lib.include_paths {
             builder.include(inc);
         }
-
-        // Adds a cfg to identify MS-MPI
-        println!("cargo:rustc-cfg=msmpi");
-    } else {
-        // Use `mpicc` wrapper on Unix rather than the system C compiler.
-        builder.compiler("mpicc");
     }
 
     let compiler = builder.try_get_compiler();


### PR DESCRIPTION
This is tested with `PrgEnv-aocc` on [NERSC Perlmutter](https://www.nersc.gov/systems/perlmutter/). It detects the environment and finds it by default based on `CRAY_MPICH_DIR`. It did not work with `PngEnv-cray`, but I think thsi needs to be fixed in [clang-sys](https://github.com/KyleMayes/clang-sys/issues/143). I expect it will work with upstream clang on Cray.

I also fixed some incomplete propagation of `mpicc` and include paths that previously caused `rsmpi.c` to be compiled using default paths, and thus fail or build for the wrong MPI when intending to use a non-default MPI.

@skailasa or @tbetcke Would you be able to test this on one of your systems?