### PR TITLE
Allow receiving into `MaybeUninit<T>` where `T: Equivalence`

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -213,6 +213,14 @@ equivalent_system_datatype!(usize, ffi::RSMPI_UINT64_T);
 #[cfg(target_pointer_width = "64")]
 equivalent_system_datatype!(isize, ffi::RSMPI_INT64_T);
 
+unsafe impl<T: Equivalence> Equivalence for mem::MaybeUninit<T> {
+    type Out = T::SystemDatatype;
+
+    fn equivalent_datatype() -> Self::Out {
+        T::equivalent_datatype()
+    }
+}
+
 /// A user defined MPI datatype
 ///
 /// # Standard section(s)


### PR DESCRIPTION
This PR implements `Equivalence` for `MaybeUninit<T>` where `T: Equivalence` by forwarding the impl to `T`. This is useful, for instance, when receiving into the spare capacity of a `Vec<T>`, which is returned as `&mut [MaybeUninit<T>]`, in order to avoid having uninitialised items.