### PR TITLE
Add documentation link to example project for using rsmpi with mpi4py

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ See files in [examples/][examples]. These examples also act as [integration test
 
 ## Python integration
 
-It is possible to use `rsmpi` with a communicator provided by mpi4py. An example project demonstrating this is available at
+It is possible to use `rsmpi` with a communicator provided by `mpi4py`. An example project demonstrating this is available at
 
 [https://github.com/betckegroup/mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi).
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ See files in [examples/][examples]. These examples also act as [integration test
 
 [examples]: https://github.com/rsmpi/rsmpi/tree/master/examples
 
+## Python integration
+
+It is possible to use rsmpi with a communicator provided by mpi4py. An example project demonstrating this is available at
+
+[https://github.com/betckegroup/mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi)
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ See files in [examples/][examples]. These examples also act as [integration test
 
 ## Python integration
 
-It is possible to use rsmpi with a communicator provided by mpi4py. An example project demonstrating this is available at
+It is possible to use `rsmpi` with a communicator provided by mpi4py. An example project demonstrating this is available at
 
-[https://github.com/betckegroup/mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi)
+[https://github.com/betckegroup/mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -215,9 +215,7 @@ See files in [examples/][examples]. These examples also act as [integration test
 
 ## Python integration
 
-It is possible to use `rsmpi` with a communicator provided by `mpi4py`. An example project demonstrating this is available at
-
-[https://github.com/betckegroup/mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi).
+It is possible to use `rsmpi` with a communicator provided by [mpi4py](https://mpi4py.readthedocs.io/en/stable/). An example project demonstrating this is [mpi4py_with_rsmpi](https://github.com/betckegroup/mpi4py_with_rsmpi).
 
 ## License
 


### PR DESCRIPTION
As suggested in #118 I have created a documentation link to an example project that uses mpi4py with rsmpi. If there are more example bindings to other langauges this may move into a subdirectory of rsmpi. But given there is only one example it might be easiest to just add a documentation link for now.