### PR TITLE
CI: allow default llvm in Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Install (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install llvm -y
+          choco install llvm --version 14.0.6 --allow-downgrade -y
           sh ci/install-mpi-windows.sh
           echo MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\" | tee -a $GITHUB_ENV
           echo MSMPI_LIB32="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\" | tee -a $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Install (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install llvm --version 14.0.6 -y
+          choco install llvm -y
           sh ci/install-mpi-windows.sh
           echo MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\" | tee -a $GITHUB_ENV
           echo MSMPI_LIB32="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\" | tee -a $GITHUB_ENV


### PR DESCRIPTION
Choco with --version 14.0.6 errors with the following. It seems more important to test newer versions than to pin to an old version (and I'd rather not expand the matrix) so we can keep the install but accept the default version.

Failures
 - llvm - A newer version of llvm (v15.0.5) is already installed. Use --allow-downgrade or --force to attempt to install older versions, or use --side-by-side to allow multiple versions.