### PR TITLE
Remove type-distinction between system-communicators and user-communicators

### DIFF
--- a/examples/immediate_multiple_test.rs
+++ b/examples/immediate_multiple_test.rs
@@ -7,8 +7,8 @@ use mpi::Rank;
 const COUNT: usize = 128;
 
 /// Send and receive COUNT number of immediate requests.
-fn send_recv<'a, C: Communicator, S: Scope<'a> + Copy>(
-    world: C,
+fn send_recv<'a, S: Scope<'a> + Copy>(
+    world: &impl Communicator,
     scope: S,
     coll: &mut RequestCollection<'a, [i32; 4]>,
     next_proc: Rank,
@@ -54,15 +54,7 @@ fn main() {
         .collect();
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(
-            universe.world(),
-            scope,
-            coll,
-            next_proc,
-            prev_proc,
-            &x,
-            &mut recv,
-        );
+        send_recv(&world, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut buf = vec![];
         while coll.incomplete() > 0 {
@@ -75,15 +67,7 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(
-            universe.world(),
-            scope,
-            coll,
-            next_proc,
-            prev_proc,
-            &x,
-            &mut recv,
-        );
+        send_recv(&world, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut complete = vec![];
         let mut buf = vec![];
@@ -99,15 +83,7 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(
-            universe.world(),
-            scope,
-            coll,
-            next_proc,
-            prev_proc,
-            &x,
-            &mut recv,
-        );
+        send_recv(&world, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut complete = vec![];
         while !coll.test_all(&mut complete) {}

--- a/examples/immediate_multiple_test.rs
+++ b/examples/immediate_multiple_test.rs
@@ -1,9 +1,9 @@
 /// Example showing usage of test_any(), test_some() and test_all().
 use mpi;
 use mpi::request::{RequestCollection, Scope};
+use mpi::topology::SimpleCommunicator;
 use mpi::traits::*;
 use mpi::Rank;
-use mpi::topology::SimpleCommunicator;
 
 const COUNT: usize = 128;
 
@@ -55,7 +55,15 @@ fn main() {
         .collect();
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(
+            SimpleCommunicator::WorldCommunicator,
+            scope,
+            coll,
+            next_proc,
+            prev_proc,
+            &x,
+            &mut recv,
+        );
 
         let mut buf = vec![];
         while coll.incomplete() > 0 {
@@ -68,7 +76,15 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(
+            SimpleCommunicator::WorldCommunicator,
+            scope,
+            coll,
+            next_proc,
+            prev_proc,
+            &x,
+            &mut recv,
+        );
 
         let mut complete = vec![];
         let mut buf = vec![];
@@ -84,7 +100,15 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(
+            SimpleCommunicator::WorldCommunicator,
+            scope,
+            coll,
+            next_proc,
+            prev_proc,
+            &x,
+            &mut recv,
+        );
 
         let mut complete = vec![];
         while !coll.test_all(&mut complete) {}

--- a/examples/immediate_multiple_test.rs
+++ b/examples/immediate_multiple_test.rs
@@ -3,6 +3,7 @@ use mpi;
 use mpi::request::{RequestCollection, Scope};
 use mpi::traits::*;
 use mpi::Rank;
+use mpi::topology::SimpleCommunicator;
 
 const COUNT: usize = 128;
 
@@ -54,7 +55,7 @@ fn main() {
         .collect();
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut buf = vec![];
         while coll.incomplete() > 0 {
@@ -67,7 +68,7 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut complete = vec![];
         let mut buf = vec![];
@@ -83,7 +84,7 @@ fn main() {
 
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
-        send_recv(world, scope, coll, next_proc, prev_proc, &x, &mut recv);
+        send_recv(SimpleCommunicator::WorldCommunicator, scope, coll, next_proc, prev_proc, &x, &mut recv);
 
         let mut complete = vec![];
         while !coll.test_all(&mut complete) {}

--- a/examples/immediate_multiple_test.rs
+++ b/examples/immediate_multiple_test.rs
@@ -1,7 +1,6 @@
 /// Example showing usage of test_any(), test_some() and test_all().
 use mpi;
 use mpi::request::{RequestCollection, Scope};
-use mpi::topology::SimpleCommunicator;
 use mpi::traits::*;
 use mpi::Rank;
 
@@ -56,7 +55,7 @@ fn main() {
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
         send_recv(
-            SimpleCommunicator::WorldCommunicator,
+            universe.world(),
             scope,
             coll,
             next_proc,
@@ -77,7 +76,7 @@ fn main() {
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
         send_recv(
-            SimpleCommunicator::WorldCommunicator,
+            universe.world(),
             scope,
             coll,
             next_proc,
@@ -101,7 +100,7 @@ fn main() {
     let mut recv: Vec<[i32; 4]> = vec![[0, 0, 0, 0]; COUNT];
     mpi::request::multiple_scope(2 * COUNT, |scope, coll| {
         send_recv(
-            SimpleCommunicator::WorldCommunicator,
+            universe.world(),
             scope,
             coll,
             next_proc,

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
 use mpi::{
-    topology::{Communicator, SystemCommunicator},
+    topology::{Communicator, SimpleCommunicator},
     traits::*,
 };
 
-fn assert_equivalence<A, B>(comm: &SystemCommunicator, a: &A, b: &B)
+fn assert_equivalence<A, B>(comm: &SimpleCommunicator, a: &A, b: &B)
 where
     A: Buffer,
     B: BufferMut + PartialEq + Debug + Default,

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,11 +1,8 @@
 use std::fmt::Debug;
 
-use mpi::{
-    topology::{Communicator, SimpleCommunicator},
-    traits::*,
-};
+use mpi::{topology::Communicator, traits::*};
 
-fn assert_equivalence<A, B>(comm: &SimpleCommunicator, a: &A, b: &B)
+fn assert_equivalence<A, B>(comm: &impl Communicator, a: &A, b: &B)
 where
     A: Buffer,
     B: BufferMut + PartialEq + Debug + Default,

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -28,9 +28,7 @@ use crate::datatype::traits::*;
 use crate::datatype::{DatatypeRef, DynBuffer, DynBufferMut};
 use crate::raw::traits::*;
 use crate::request::{Request, Scope, StaticScope};
-use crate::topology::{
-    traits::*, InterCommunicator, SimpleCommunicatorHandle, UserInterCommunicator,
-};
+use crate::topology::{traits::*, CommunicatorHandle, InterCommunicator};
 use crate::topology::{Process, Rank};
 use crate::with_uninitialized;
 
@@ -1552,7 +1550,7 @@ pub trait Root: AsCommunicator {
     ///
     /// # Standard sections
     /// 10.3.2, see MPI_Comm_spawn
-    fn spawn(&self, command: &Command, maxprocs: Rank) -> Result<UserInterCommunicator, MpiError> {
+    fn spawn(&self, command: &Command, maxprocs: Rank) -> Result<InterCommunicator, MpiError> {
         // Environment variables can be handled using the info key
         assert_eq!(
             command.get_envs().len(),
@@ -1611,7 +1609,7 @@ pub trait Root: AsCommunicator {
         } else {
             Ok(unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    SimpleCommunicatorHandle::from_raw(result).unwrap(),
+                    CommunicatorHandle::inter_from_raw_unchecked(result),
                 )
             })
         }
@@ -1625,7 +1623,7 @@ pub trait Root: AsCommunicator {
         &self,
         commands: &[Command],
         maxprocs: &[Rank],
-    ) -> Result<UserInterCommunicator, MpiError> {
+    ) -> Result<InterCommunicator, MpiError> {
         assert_eq!(commands.len(), maxprocs.len());
 
         let progs = commands
@@ -1685,7 +1683,7 @@ pub trait Root: AsCommunicator {
         } else {
             Ok(unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    SimpleCommunicatorHandle::from_raw(result).unwrap(),
+                    CommunicatorHandle::inter_from_raw_unchecked(result),
                 )
             })
         }

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1607,7 +1607,7 @@ pub trait Root: AsCommunicator {
         if fails > 0 {
             Err(MpiError::Spawn(fails as Rank, maxprocs))
         } else {
-            Ok(unsafe { InterCommunicator::from_raw_unchecked(result) })
+            Ok(unsafe { InterCommunicator::from_raw(result) })
         }
     }
 

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -1607,11 +1607,7 @@ pub trait Root: AsCommunicator {
         if fails > 0 {
             Err(MpiError::Spawn(fails as Rank, maxprocs))
         } else {
-            Ok(unsafe {
-                InterCommunicator::from_handle_unchecked(
-                    CommunicatorHandle::inter_from_raw_unchecked(result),
-                )
-            })
+            Ok(unsafe { InterCommunicator::from_raw_unchecked(result) })
         }
     }
 

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -29,7 +29,7 @@ use crate::datatype::{DatatypeRef, DynBuffer, DynBufferMut};
 use crate::raw::traits::*;
 use crate::request::{Request, Scope, StaticScope};
 use crate::topology::{
-    traits::*, InterCommunicator, UserCommunicatorHandle, UserInterCommunicator,
+    traits::*, InterCommunicator, SimpleCommunicatorHandle, UserInterCommunicator,
 };
 use crate::topology::{Process, Rank};
 use crate::with_uninitialized;
@@ -1611,7 +1611,7 @@ pub trait Root: AsCommunicator {
         } else {
             Ok(unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    UserCommunicatorHandle::from_raw(result).unwrap(),
+                    SimpleCommunicatorHandle::from_raw(result).unwrap(),
                 )
             })
         }
@@ -1685,7 +1685,7 @@ pub trait Root: AsCommunicator {
         } else {
             Ok(unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    UserCommunicatorHandle::from_raw(result).unwrap(),
+                    SimpleCommunicatorHandle::from_raw(result).unwrap(),
                 )
             })
         }

--- a/src/collective.rs
+++ b/src/collective.rs
@@ -28,7 +28,7 @@ use crate::datatype::traits::*;
 use crate::datatype::{DatatypeRef, DynBuffer, DynBufferMut};
 use crate::raw::traits::*;
 use crate::request::{Request, Scope, StaticScope};
-use crate::topology::{traits::*, CommunicatorHandle, InterCommunicator};
+use crate::topology::{traits::*, InterCommunicator};
 use crate::topology::{Process, Rank};
 use crate::with_uninitialized;
 
@@ -1677,11 +1677,7 @@ pub trait Root: AsCommunicator {
         if fails > 0 {
             Err(MpiError::Spawn(fails as Rank, sum_maxprocs))
         } else {
-            Ok(unsafe {
-                InterCommunicator::from_handle_unchecked(
-                    CommunicatorHandle::inter_from_raw_unchecked(result),
-                )
-            })
+            Ok(unsafe { InterCommunicator::from_raw(result) })
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -20,6 +20,7 @@ use std::{
 use conv::ConvUtil;
 use once_cell::sync::Lazy;
 
+use crate::traits::FromRaw;
 use crate::{ffi, topology::SystemAttribute};
 use crate::{
     topology::{Communicator, InterCommunicator, SimpleCommunicator},
@@ -135,7 +136,7 @@ impl Universe {
         if let Some(parent) = self.world().parent() {
             // Make it look like a user communicator so it can be dropped
             // TODO why is this implemented like this instead of calling MPI_Comm_disconnect directly?
-            let _p = unsafe { InterCommunicator::from_raw_unchecked(parent.as_raw()) };
+            let _p = unsafe { InterCommunicator::from_raw(parent.as_raw()) };
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 
 use crate::{ffi, topology::SystemAttribute};
 use crate::{
-    topology::{Communicator, InterCommunicator, SimpleCommunicator, UserCommunicatorHandle},
+    topology::{Communicator, InterCommunicator, SimpleCommunicator, SimpleCommunicatorHandle},
     traits::AsRaw,
 };
 use crate::{with_uninitialized, with_uninitialized2};
@@ -136,7 +136,7 @@ impl Universe {
             // Make it look like a user communicator so it can be dropped
             let _p = unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    UserCommunicatorHandle::from_raw(parent.as_raw()).unwrap(),
+                    SimpleCommunicatorHandle::from_raw(parent.as_raw()).unwrap(),
                 )
             };
         }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -135,7 +135,6 @@ impl Universe {
     pub fn disconnect_parent(&mut self) {
         if let Some(parent) = self.world().parent() {
             // Make it look like a user communicator so it can be dropped
-            // TODO why is this implemented like this instead of calling MPI_Comm_disconnect directly?
             let _p = unsafe { InterCommunicator::from_raw(parent.as_raw()) };
         }
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -20,9 +20,10 @@ use std::{
 use conv::ConvUtil;
 use once_cell::sync::Lazy;
 
+use crate::topology::CommunicatorHandle;
 use crate::{ffi, topology::SystemAttribute};
 use crate::{
-    topology::{Communicator, InterCommunicator, SimpleCommunicator, SimpleCommunicatorHandle},
+    topology::{Communicator, InterCommunicator, SimpleCommunicator},
     traits::AsRaw,
 };
 use crate::{with_uninitialized, with_uninitialized2};
@@ -134,9 +135,10 @@ impl Universe {
     pub fn disconnect_parent(&mut self) {
         if let Some(parent) = self.world().parent() {
             // Make it look like a user communicator so it can be dropped
+            // TODO why is this implemented like this instead of calling MPI_Comm_disconnect directly?
             let _p = unsafe {
                 InterCommunicator::from_handle_unchecked(
-                    SimpleCommunicatorHandle::from_raw(parent.as_raw()).unwrap(),
+                    CommunicatorHandle::inter_from_raw_unchecked(parent.as_raw()),
                 )
             };
         }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 
 use crate::{ffi, topology::SystemAttribute};
 use crate::{
-    topology::{Communicator, InterCommunicator, SystemCommunicator, UserCommunicatorHandle},
+    topology::{Communicator, InterCommunicator, SimpleCommunicator, UserCommunicatorHandle},
     traits::AsRaw,
 };
 use crate::{with_uninitialized, with_uninitialized2};
@@ -49,8 +49,8 @@ impl Universe {
     ///
     /// # Examples
     /// See `examples/simple.rs`
-    pub fn world(&self) -> SystemCommunicator {
-        SystemCommunicator::world()
+    pub fn world(&self) -> SimpleCommunicator {
+        SimpleCommunicator::world()
     }
 
     /// Total number of "slots" that can reasonably be filled in the environment

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -20,7 +20,6 @@ use std::{
 use conv::ConvUtil;
 use once_cell::sync::Lazy;
 
-use crate::topology::CommunicatorHandle;
 use crate::{ffi, topology::SystemAttribute};
 use crate::{
     topology::{Communicator, InterCommunicator, SimpleCommunicator},
@@ -136,11 +135,7 @@ impl Universe {
         if let Some(parent) = self.world().parent() {
             // Make it look like a user communicator so it can be dropped
             // TODO why is this implemented like this instead of calling MPI_Comm_disconnect directly?
-            let _p = unsafe {
-                InterCommunicator::from_handle_unchecked(
-                    CommunicatorHandle::inter_from_raw_unchecked(parent.as_raw()),
-                )
-            };
+            let _p = unsafe { InterCommunicator::from_raw_unchecked(parent.as_raw()) };
         }
     }
 }

--- a/src/topology/cartesian.rs
+++ b/src/topology/cartesian.rs
@@ -53,7 +53,7 @@ impl CartesianCommunicator {
     /// - `raw` must be a live MPI_Comm object.
     /// - `raw` must not be used after calling `from_raw`.
     pub unsafe fn from_raw(raw: MPI_Comm) -> Option<CartesianCommunicator> {
-        SimpleCommunicator::from_raw(raw).and_then(|comm| match comm.into_topology() {
+        SimpleCommunicator::from_raw_checked(raw).and_then(|comm| match comm.into_topology() {
             IntoTopology::Cartesian(c) => Some(c),
             incorrect => {
                 // Forget the comm object so it's not dropped
@@ -75,7 +75,7 @@ impl CartesianCommunicator {
     /// - `raw` must not be `MPI_COMM_NULL`.
     pub unsafe fn from_raw_unchecked(raw: MPI_Comm) -> CartesianCommunicator {
         debug_assert_ne!(raw, ffi::RSMPI_COMM_NULL);
-        CartesianCommunicator(SimpleCommunicator::from_raw_unchecked(raw))
+        CartesianCommunicator(SimpleCommunicator::from_raw(raw))
     }
 
     /// Returns the number of dimensions that the Cartesian communicator was established over.

--- a/src/topology/cartesian.rs
+++ b/src/topology/cartesian.rs
@@ -4,11 +4,11 @@ use conv::ConvUtil;
 
 use super::{AsCommunicator, Communicator, IntoTopology, Rank};
 use crate::ffi::MPI_Comm;
+use crate::topology::SimpleCommunicator;
 use crate::{
     datatype::traits::*, ffi, raw::traits::*, with_uninitialized, with_uninitialized2, Count,
     IntArray,
 };
-use crate::topology::SimpleCommunicator;
 
 /// Contains arrays describing the layout of the
 /// [`CartesianCommunicator`](struct.CartesianCommunicator.html).

--- a/src/topology/cartesian.rs
+++ b/src/topology/cartesian.rs
@@ -2,12 +2,13 @@ use std::mem;
 
 use conv::ConvUtil;
 
-use super::{AsCommunicator, Communicator, IntoTopology, Rank, UserCommunicator};
+use super::{AsCommunicator, Communicator, IntoTopology, Rank};
 use crate::ffi::MPI_Comm;
 use crate::{
     datatype::traits::*, ffi, raw::traits::*, with_uninitialized, with_uninitialized2, Count,
     IntArray,
 };
+use crate::topology::SimpleCommunicator;
 
 /// Contains arrays describing the layout of the
 /// [`CartesianCommunicator`](struct.CartesianCommunicator.html).
@@ -35,7 +36,7 @@ pub struct CartesianLayout {
 /// # Standard Section(s)
 ///
 /// 7
-pub struct CartesianCommunicator(pub(crate) UserCommunicator);
+pub struct CartesianCommunicator(pub(crate) SimpleCommunicator);
 
 impl CartesianCommunicator {
     /// Given a valid `MPI_Comm` handle in `raw`, returns a `CartesianCommunicator` value if, and
@@ -52,7 +53,7 @@ impl CartesianCommunicator {
     /// - `raw` must be a live MPI_Comm object.
     /// - `raw` must not be used after calling `from_raw`.
     pub unsafe fn from_raw(raw: MPI_Comm) -> Option<CartesianCommunicator> {
-        UserCommunicator::from_raw(raw).and_then(|comm| match comm.into_topology() {
+        SimpleCommunicator::from_raw(raw).and_then(|comm| match comm.into_topology() {
             IntoTopology::Cartesian(c) => Some(c),
             incorrect => {
                 // Forget the comm object so it's not dropped
@@ -74,7 +75,7 @@ impl CartesianCommunicator {
     /// - `raw` must not be `MPI_COMM_NULL`.
     pub unsafe fn from_raw_unchecked(raw: MPI_Comm) -> CartesianCommunicator {
         debug_assert_ne!(raw, ffi::RSMPI_COMM_NULL);
-        CartesianCommunicator(UserCommunicator::from_raw_unchecked(raw))
+        CartesianCommunicator(SimpleCommunicator::from_raw_unchecked(raw))
     }
 
     /// Returns the number of dimensions that the Cartesian communicator was established over.

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -354,8 +354,7 @@ pub struct InterCommunicator(pub(crate) CommunicatorHandle);
 
 impl InterCommunicator {
     /// Construct an Intercommunicator from a raw handle
-    // TODO this was public, but why?
-    pub(crate) fn from_handle(handle: CommunicatorHandle) -> Option<Self> {
+    pub fn from_handle(handle: CommunicatorHandle) -> Option<Self> {
         if handle.is_inter_comm() {
             Some(InterCommunicator(handle))
         } else {
@@ -364,8 +363,7 @@ impl InterCommunicator {
     }
 
     /// Construct an Intercommunicator from a raw handle without checking if it's an Intercomm
-    // TODO this was public but why?
-    pub(crate) unsafe fn from_handle_unchecked(handle: CommunicatorHandle) -> Self {
+    pub unsafe fn from_handle_unchecked(handle: CommunicatorHandle) -> Self {
         debug_assert!(handle.is_inter_comm());
         InterCommunicator(handle)
     }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -153,8 +153,8 @@ unsafe impl AsRaw for SimpleCommunicator {
     type Raw = MPI_Comm;
     fn as_raw(&self) -> Self::Raw {
         match self {
-            SimpleCommunicator::WorldCommunicator => unsafe { ffi::RSMPI_COMM_WORLD }
-            SimpleCommunicator::SelfCommunicator => unsafe { ffi::RSMPI_COMM_SELF }
+            SimpleCommunicator::WorldCommunicator => unsafe { ffi::RSMPI_COMM_WORLD },
+            SimpleCommunicator::SelfCommunicator => unsafe { ffi::RSMPI_COMM_SELF },
             SimpleCommunicator::UserCommunicator(r) => *r,
         }
     }
@@ -241,7 +241,7 @@ impl Drop for SimpleCommunicator {
             SimpleCommunicator::UserCommunicator(comm) => unsafe {
                 ffi::MPI_Comm_free(comm);
                 assert_eq!(*comm, ffi::RSMPI_COMM_NULL);
-            }
+            },
         }
     }
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -662,7 +662,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// 6.4.2
     #[cfg(not(msmpi))]
-    fn split_by_subgroup<G: ?Sized>(&self, group: &G) -> Option<UserCommunicator>
+    fn split_by_subgroup<G: ?Sized>(&self, group: &G) -> Option<SimpleCommunicator>
     where
         G: Group,
         Self: Sized,
@@ -679,13 +679,13 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// 6.4.2
     #[cfg(not(msmpi))]
-    fn split_by_subgroup_with_tag<G: ?Sized>(&self, group: &G, tag: Tag) -> Option<UserCommunicator>
+    fn split_by_subgroup_with_tag<G: ?Sized>(&self, group: &G, tag: Tag) -> Option<SimpleCommunicator>
     where
         G: Group,
         Self: Sized,
     {
         unsafe {
-            UserCommunicator::from_raw(
+            SimpleCommunicator::from_raw(
                 with_uninitialized(|newcomm| {
                     ffi::MPI_Comm_create_group(self.as_raw(), group.as_raw(), tag, newcomm)
                 })

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -63,12 +63,19 @@ pub type Rank = c_int;
 /// A communicator, either built-in or user-defined, e.g. through split
 #[derive(Clone)]
 pub enum SimpleCommunicator {
-    /// A built-in communicator, e.g. `MPI_COMM_WORLD`
+    /// Built-in communicator `MPI_COMM_WORLD`
     ///
     /// # Standard section(s)
     ///
-    /// 6.4
+    /// 6.2
     WorldCommunicator,
+
+    /// Built-in communicator `MPI_COMM_SELF`
+    ///
+    /// # Standard section(s)
+    ///
+    /// 6.2
+    SelfCommunicator,
 
     /// A user-defined communicator
     ///
@@ -147,7 +154,8 @@ unsafe impl AsRaw for SimpleCommunicator {
     fn as_raw(&self) -> Self::Raw {
         match self {
             SimpleCommunicator::WorldCommunicator => unsafe { ffi::RSMPI_COMM_WORLD }
-            SimpleCommunicator::UserCommunicator(r) => *r
+            SimpleCommunicator::SelfCommunicator => unsafe { ffi::RSMPI_COMM_SELF }
+            SimpleCommunicator::UserCommunicator(r) => *r,
         }
     }
 }
@@ -229,7 +237,7 @@ pub enum IntoTopology {
 impl Drop for SimpleCommunicator {
     fn drop(&mut self) {
         match self {
-            SimpleCommunicator::WorldCommunicator => {}
+            SimpleCommunicator::WorldCommunicator | SimpleCommunicator::SelfCommunicator => {}
             SimpleCommunicator::UserCommunicator(comm) => unsafe {
                 ffi::MPI_Comm_free(comm);
                 assert_eq!(*comm, ffi::RSMPI_COMM_NULL);

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -302,8 +302,10 @@ impl FromRaw for SimpleCommunicator {
     /// Wraps the raw value without checking for null handle
     ///
     /// # Safety
-    /// Do not call with inter-comm handles and inter-comm parent handles, `MPI_COMM_WORLD`, or
-    /// `MPI_COMM_SELF`
+    /// - `handle` must be a live MPI_Comm object.
+    /// - `handle` must not be an inter-comm handle, an inter-comm parent handle, `MPI_COMM_WORLD`,
+    /// or `MPI_COMM_SELF`
+    /// - `handle` must not be used after calling `from_raw`.
     unsafe fn from_raw(handle: <Self as AsRaw>::Raw) -> Self {
         debug_assert_ne!(handle, ffi::RSMPI_COMM_NULL);
         let handle = CommunicatorHandle::simple_from_raw_unchecked(handle);
@@ -443,7 +445,9 @@ impl FromRaw for InterCommunicator {
     /// Construct an `InterCommunicator` from a raw handle without checking if it's an Intercomm
     /// handle
     /// # Safety
-    /// Do only call with handles that are inter-comms or inter-comm parent
+    /// - `handle` must be a live MPI_Comm object.
+    /// - `handle` must be an inter-comms or inter-comm parent handle
+    /// - `handle` must not be used after calling `from_raw`.
     unsafe fn from_raw(handle: <Self as AsRaw>::Raw) -> Self {
         Self::from_handle_unchecked(CommunicatorHandle::inter_from_raw_unchecked(handle))
     }
@@ -860,7 +864,7 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
                 reorder as Count,
                 &mut comm_cart,
             );
-            CartesianCommunicator::from_raw(comm_cart)
+            CartesianCommunicator::from_raw_checked(comm_cart)
         }
     }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -196,7 +196,7 @@ impl Drop for CommunicatorHandle {
         match self {
             CommunicatorHandle::SelfComm => { /* cannot be dropped */ }
             CommunicatorHandle::World => { /* cannot be dropped */ }
-            CommunicatorHandle::Parent(_) => { /* should be dropped */ }
+            CommunicatorHandle::Parent(_) => { /* not useful to drop (would nullify other references) */ }
             CommunicatorHandle::User(handle) => unsafe {
                 ffi::MPI_Comm_free(handle);
                 assert_eq!(*handle, ffi::RSMPI_COMM_NULL);

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -61,7 +61,6 @@ pub trait CommunicatorHandle: AsRaw<Raw = MPI_Comm> {}
 pub type Rank = c_int;
 
 /// A communicator, either built-in or user-defined, e.g. through split
-#[derive(Clone)]
 pub enum SimpleCommunicator {
     /// Built-in communicator `MPI_COMM_WORLD`
     ///
@@ -679,7 +678,11 @@ pub trait Communicator: AsRaw<Raw = MPI_Comm> {
     ///
     /// 6.4.2
     #[cfg(not(msmpi))]
-    fn split_by_subgroup_with_tag<G: ?Sized>(&self, group: &G, tag: Tag) -> Option<SimpleCommunicator>
+    fn split_by_subgroup_with_tag<G: ?Sized>(
+        &self,
+        group: &G,
+        tag: Tag,
+    ) -> Option<SimpleCommunicator>
     where
         G: Group,
         Self: Sized,


### PR DESCRIPTION
As outlined in #148, it is very unintuitive to split the Communicator interface in `SystemCommunicator` and `UserCommunicator`.
I drafted a PR to unify both into one common `enum SimpleCommunicator`:

- I migrated topology-related code from UserCommunicator into the common enum, so both communicator variants can now call those functions. I couldn't confirm it outright, but the spec does not prohibit that explicitely, so I think this models the MPI interface more closely.
- I refactored CartesianCommunicator to accept both World- and UserCommunicator, which is legal by spec, I don't know why this wasn't possible before.
- since WorldCommunicator is no longer Copy, code that moved a reference to SystemCommunicator must now explicitly refer to IntraCommunicator::WorldCommunicator (see immediate_multiple_test.rs)
- I added SelfCommunicator next to WorldCommunicator, because the MPI spec defines it and without it downstream crates would need unsafe code to create it, and call `free` on it when their `UserCommunicator` drops

Things missing from this draft:

There is another weird split in the code-base: InterCommunicators use `SystemCommunicatorHandle` and `UserCommunicatorHandle`, even though those handle structs do the exact same as their communicator-counterparts (at least as far as I can tell).
Since I have never worked with InterCommunicators before though, and there are neither integration-tests nor examples for them, I didn't migrate them to use `SimpleCommunicator` yet, as I wanted to get some feedback on their purpose.

All examples and tests are green, but I am not very familiar with the codebase yet, so somebody should scrutinize this.

