### PR TITLE
Refactor attributes and add support for setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # RSMPI Release Notes
 
+## `main` branch
+
+### New Features
+
+* [[PR 171]](https://github.com/rsmpi/rsmpi/pull/171) Refactor attributes to safer approach; add `Communicator::set_attr()`.`
+
 ## 0.7.0 (2023-10-21)
 
 **MSRV:** 1.65

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -1,9 +1,65 @@
-#![deny(warnings)]
-
 use mpi::traits::*;
+
+#[derive(Debug, PartialEq)]
+struct MyData1(i32);
+
+impl CommAttribute for MyData1 {
+    const CLONE_ON_DUP: bool = true;
+}
+
+// These implementations are only for logging
+impl Drop for MyData1 {
+    fn drop(&mut self) {
+        println!("Dropping: {self:?}");
+    }
+}
+
+impl Clone for MyData1 {
+    fn clone(&self) -> Self {
+        println!("Cloning: {self:?}");
+        Self(self.0 + 1)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct MyData2(i32);
+
+impl CommAttribute for MyData2 {}
+
+impl Drop for MyData2 {
+    fn drop(&mut self) {
+        println!("Dropping: {self:?}");
+    }
+}
+
+impl Clone for MyData2 {
+    fn clone(&self) -> Self {
+        println!("Cloning: {self:?}");
+        Self(self.0 + 1)
+    }
+}
+
+fn with_trait_object(comm: &mut dyn Communicator) {
+    comm.set_attr(MyData2(22));
+    println!("Got from comm2: {:?}", comm.get_attr::<MyData2>());
+}
 
 fn main() {
     let universe = mpi::initialize().unwrap();
     println!("Universe: {:?}", universe.size());
-    println!("World   : {}", universe.world().size());
+    let mut world = universe.world();
+    println!("World   : {}", world.size());
+    world.set_attr(MyData1(10));
+    world.set_attr(MyData2(20));
+    assert_eq!(world.get_attr::<MyData1>(), Some(MyData1(10)).as_ref());
+    println!("Got from world: {:?}", world.get_attr::<MyData1>());
+    assert_eq!(world.get_attr::<MyData2>(), Some(MyData2(20)).as_ref());
+    println!("Got from world: {:?}", world.get_attr::<MyData2>());
+    let comm = world.duplicate();
+    assert_eq!(comm.get_attr::<MyData1>(), Some(MyData1(11)).as_ref());
+    println!("Got from comm: {:?}", comm.get_attr::<MyData1>());
+    assert_eq!(comm.get_attr::<MyData2>(), None);
+    println!("Got from comm: {:?}", comm.get_attr::<MyData2>());
+    let mut comm2 = comm.duplicate();
+    with_trait_object(&mut comm2);
 }

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::*;
 
 #[derive(Debug, PartialEq)]

--- a/examples/complex_numbers.rs
+++ b/examples/complex_numbers.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::*;
 use num_complex::Complex64;
 

--- a/examples/derive_multiple_thread_init.rs
+++ b/examples/derive_multiple_thread_init.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::Equivalence;
 
 fn main() {

--- a/examples/derive_nonthreaded_panic.rs
+++ b/examples/derive_nonthreaded_panic.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::Equivalence;
 
 fn main() {

--- a/examples/derive_postfinalize_panic.rs
+++ b/examples/derive_postfinalize_panic.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::Equivalence;
 
 fn main() {

--- a/examples/derive_preinit_panic.rs
+++ b/examples/derive_preinit_panic.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use mpi::traits::Equivalence;
 
 fn main() {

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::env;
 use std::process::Command;
 

--- a/examples/spawn.rs
+++ b/examples/spawn.rs
@@ -33,10 +33,11 @@ fn main() -> Result<(), mpi::MpiError> {
             assert_eq!(7i32, child.process_at_rank(0).receive().0);
         }
         println!(
-            "[{}/{}] Parent universe {:?}",
+            "[{}/{}] Parent universe {:?} appnum {}",
             world.rank(),
             world.size(),
             universe.size(),
+            universe.appnum().unwrap_or(-1),
         );
         child.merge(MergeOrder::Low)
     };

--- a/examples/spawn_multiple.rs
+++ b/examples/spawn_multiple.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::env;
 use std::process::Command;
 

--- a/examples/spawn_multiple.rs
+++ b/examples/spawn_multiple.rs
@@ -9,11 +9,13 @@ fn main() -> Result<(), mpi::MpiError> {
 
     if let Some(parent) = world.parent() {
         let child_name = env::args().skip(1).next().unwrap();
+        let appnum = universe.appnum().unwrap_or(-1);
         println!(
-            "[{}/{}] {} has parent size {}, universe {:?}",
+            "[{}/{}] {} ({}) has parent size {}, universe {:?}",
             world.rank(),
             world.size(),
             child_name,
+            appnum,
             parent.remote_size(),
             universe.size(),
         );

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::fmt::Debug;
 
 use mpi::{topology::Communicator, traits::*};

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,0 +1,193 @@
+//! Attribute caching on communicators
+
+use std::{any::TypeId, collections::HashMap, ffi::c_void, os::raw::c_int, ptr, sync::RwLock};
+
+use once_cell::sync::Lazy;
+
+use crate::{ffi, traits::AsRaw};
+
+/// Topology traits
+pub mod traits {
+    pub use super::CommAttribute;
+}
+
+pub(crate) static COMM_ATTRS: Lazy<RwLock<HashMap<TypeId, AttributeKey>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Attributes are user data that can be owned by communicators and accessed by
+/// users. They are useful when libraries pass communicators to a different
+/// library and get it back in a callback.
+///
+/// # Standard section(s)
+///
+/// 7.7.1
+pub trait CommAttribute
+where
+    Self: 'static + Sized + Clone,
+{
+    /// When a communicator is duplicated, attributes can either be cloned to
+    /// the new communicator or not propagated at all. Implementations of
+    /// CommAttribute can determine this behavior by defining this associated
+    /// constant. The default does not propagated attributes to cloned
+    /// communicators.
+    const CLONE_ON_DUP: bool = false;
+
+    /// Callback invoked by `MPI Comm_free`, `MPI_Comm_disconnect`, and
+    /// `MPI_Comm_delete_attr` to delete an attribute.
+    ///
+    /// User-defined attributes should not need to override this default
+    /// implementation.
+    ///
+    /// # Safety
+    ///
+    /// This default implementation goes with the boxing in
+    /// `AnyCommunicator::set_attr()`.
+    unsafe extern "C" fn comm_delete_attr_fn(
+        _comm: ffi::MPI_Comm,
+        _key: c_int,
+        val: *mut c_void,
+        _extra_state: *mut c_void,
+    ) -> c_int {
+        let _to_drop = Box::from_raw(val as *mut Self);
+        ffi::MPI_SUCCESS as i32
+    }
+
+    /// Callback invoked by `MPI_Comm_dup()`, `MPI_Comm_idup()`, and variants to
+    /// (optionally) clone the attribute to the new communicator. The behavior
+    /// of this function is determined by `Self::CLONE_ON_DUP`, which should be
+    /// sufficient to obtain desired semantics.
+    ///
+    /// User-defined attributes should not need to override this default
+    /// implementation.
+    ///
+    /// # Safety
+    ///
+    /// This default implementation must only be used with boxed attributes, as
+    /// in `AnyCommunicator::set_attr()`.
+    unsafe extern "C" fn comm_copy_attr_fn(
+        _old_comm: ffi::MPI_Comm,
+        _key: c_int,
+        _extra_state: *mut c_void,
+        val_in: *mut c_void,
+        val_out: *mut c_void,
+        flag: *mut c_int,
+    ) -> c_int {
+        if Self::CLONE_ON_DUP {
+            let b_in = Box::from_raw(val_in as *mut Self);
+            let b_out = b_in.clone();
+            *(val_out as *mut *mut Self) = Box::into_raw(b_out);
+            Box::into_raw(b_in); // deconstruct to avoid dropping
+            *flag = 1;
+        } else {
+            *flag = 0;
+        }
+        ffi::MPI_SUCCESS as i32
+    }
+
+    /// Get the attribute key for this attribute. User keys are provisioned by
+    /// `MPI_Comm_create_keyval()`, which we store in the universe and free
+    /// prior to `MPI_Finalize()` when the universe is dropped.
+    ///
+    /// In multi-language projects for which `MPI_Comm_create_keyval()` is
+    /// called from a different language, the attribute can be set and retrieved
+    /// in Rust by overriding this default implementation to return the foreign
+    /// key.
+    fn get_key() -> AttributeKey {
+        let id = TypeId::of::<Self>();
+        {
+            let comm_attrs = COMM_ATTRS.read().expect("COMM_ATTRS RwLock poisoned");
+            if let Some(key) = comm_attrs.get(&id) {
+                return key.clone();
+            }
+        }
+        let mut key: i32 = 0;
+        unsafe {
+            ffi::MPI_Comm_create_keyval(
+                Some(Self::comm_copy_attr_fn),
+                Some(Self::comm_delete_attr_fn),
+                &mut key,
+                ptr::null_mut(),
+            );
+        }
+        let key = AttributeKey(key);
+        let mut comm_attrs = COMM_ATTRS.write().expect("COMM_ATTRS RwLock poisoned");
+        comm_attrs.insert(id, key.clone());
+        key
+    }
+}
+
+/// Attribute keys are used internally to access attributes. They are obtained
+/// with the associated function `CommAttribute::get_key()`.
+///
+/// User keys are created with `MPI_Comm_create_keyval()` and should be freed
+/// with `MPI_Comm_free_keyval()`. They are provisioned in the default
+/// implementation of `CommAttribute::get_key()` and stored persistently in
+/// `COMM_ATTRS`.
+///
+/// System keys are automatically available and are not passed to
+/// `MPI_Comm_free_keyval()`.
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone)]
+pub struct AttributeKey(i32);
+
+impl AttributeKey {
+    /// Create a new attribute key. This is mostly unnecessary for users, but
+    /// may be used when implementing `CommAttribute::get_key()` to be used with
+    /// a foreign keyval.
+    ///
+    /// # Safety
+    ///
+    /// The key must be a valid predefined system keyval or obtained by
+    /// `MPI_Comm_create_keyval()`. Strictly speaking, I think this can be safe,
+    /// but an invalid value will cause `MPI_Comm_get_attr()` and
+    /// `MPI_Comm_set_attr()` to fail. Note that they can also be made to fail
+    /// if `MPI_Comm_free_keyval()` is called after creating an `AttributeKey`
+    /// and before it is used. I'm leaving it `unsafe` to be defensive and
+    /// because the caller should think carefully about lifetime of their
+    /// foreign keyvals when interoperating with Rust.
+    pub unsafe fn new_unchecked(k: i32) -> Self {
+        Self(k)
+    }
+}
+
+unsafe impl AsRaw for AttributeKey {
+    type Raw = c_int;
+    fn as_raw(&self) -> Self::Raw {
+        self.0
+    }
+}
+
+/// For obtaining the universe size attribute
+#[repr(C)]
+#[derive(Clone)]
+pub(crate) struct UniverseSize(c_int);
+
+impl CommAttribute for UniverseSize {
+    fn get_key() -> AttributeKey {
+        unsafe { AttributeKey::new_unchecked(ffi::MPI_UNIVERSE_SIZE as i32) }
+    }
+}
+
+impl TryFrom<&UniverseSize> for usize {
+    type Error = std::num::TryFromIntError;
+    fn try_from(s: &UniverseSize) -> Result<Self, Self::Error> {
+        usize::try_from(s.0)
+    }
+}
+
+/// For obtaining the appnum attribute of MPI_COMM_WORLD
+#[repr(C)]
+#[derive(Clone)]
+pub(crate) struct AppNum(c_int);
+
+impl CommAttribute for AppNum {
+    fn get_key() -> AttributeKey {
+        unsafe { AttributeKey::new_unchecked(ffi::MPI_APPNUM as i32) }
+    }
+}
+
+impl From<&AppNum> for isize {
+    fn from(an: &AppNum) -> Self {
+        an.0 as isize
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub mod ffi {
     pub use mpi_sys::*;
 }
 
+pub mod attribute;
 pub mod collective;
 pub mod datatype;
 pub mod environment;
@@ -145,6 +146,7 @@ pub mod topology;
 
 /// Re-exports all traits.
 pub mod traits {
+    pub use crate::attribute::traits::*;
     pub use crate::collective::traits::*;
     pub use crate::datatype::traits::*;
     pub use crate::point_to_point::traits::*;


### PR DESCRIPTION
Attributes now hide the keys from most user code, and are easy to implement for new types. The current implementation still does not support setting/getting attributes on `dyn Communicator`.