### PR TITLE
Add equivalence trait for arrays, with integration tests

### DIFF
--- a/examples/arrays.rs
+++ b/examples/arrays.rs
@@ -1,0 +1,22 @@
+#![deny(warnings)]
+
+use mpi::traits::*;
+
+fn main() {
+    let universe = mpi::initialize().unwrap();
+    let world = universe.world();
+
+    let to_send = [1, 2, 3];
+    let future = world.any_process().immediate_receive::<[i32; 3usize]>();
+    world.this_process().send(&to_send);
+    let (msg, _status) = future.get();
+    assert_eq!(to_send, msg);
+
+    let mut msg = [0, 0, 0];
+    mpi::request::scope(|scope| {
+        let status = world.any_process().immediate_receive_into(scope, &mut msg);
+        world.this_process().send(&to_send);
+        println!("{:?}", status);
+    });
+    assert_eq!(to_send, msg);
+}

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -175,4 +175,10 @@ fn main() {
             child: Child(3.4, 7),
         },
     );
+
+    assert_equivalence(
+        &world,
+        &[true, false, true],
+        &ThreeBool([true, false, true]),
+    );
 }

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -213,6 +213,17 @@ equivalent_system_datatype!(usize, ffi::RSMPI_UINT64_T);
 #[cfg(target_pointer_width = "64")]
 equivalent_system_datatype!(isize, ffi::RSMPI_INT64_T);
 
+unsafe impl<T, const D: usize> Equivalence for [T; D]
+where
+    T: Equivalence,
+{
+    type Out = UserDatatype;
+
+    fn equivalent_datatype() -> Self::Out {
+        UserDatatype::contiguous(D as i32, &T::equivalent_datatype())
+    }
+}
+
 #[cfg(feature = "complex")]
 /// Implement direct equivalence for complex types
 pub mod complex_datatype {
@@ -807,16 +818,6 @@ where
     }
 }
 
-unsafe impl<T, const D: usize> AsDatatype for [T; D]
-where
-    T: Equivalence,
-{
-    type Out = <T as Equivalence>::Out;
-    fn as_datatype(&self) -> Self::Out {
-        <T as Equivalence>::equivalent_datatype()
-    }
-}
-
 #[doc(hidden)]
 pub mod internal {
     #[cfg(feature = "derive")]
@@ -909,17 +910,6 @@ where
     }
 }
 
-unsafe impl<T, const D: usize> Collection for [T; D]
-where
-    T: Equivalence,
-{
-    fn count(&self) -> Count {
-        // TODO const generic bound
-        D.value_as()
-            .expect("Length of slice cannot be expressed as an MPI Count.")
-    }
-}
-
 /// Provides a pointer to the starting address in memory.
 pub unsafe trait Pointer {
     /// A pointer to the starting address in memory
@@ -946,15 +936,6 @@ where
 }
 
 unsafe impl<T> Pointer for Vec<T>
-where
-    T: Equivalence,
-{
-    fn pointer(&self) -> *const c_void {
-        self.as_ptr() as _
-    }
-}
-
-unsafe impl<T, const D: usize> Pointer for [T; D]
 where
     T: Equivalence,
 {
@@ -997,22 +978,12 @@ where
     }
 }
 
-unsafe impl<T, const D: usize> PointerMut for [T; D]
-where
-    T: Equivalence,
-{
-    fn pointer_mut(&mut self) -> *mut c_void {
-        self.as_mut_ptr() as _
-    }
-}
-
 /// A buffer is a region in memory that starts at `pointer()` and contains `count()` copies of
 /// `as_datatype()`.
 pub unsafe trait Buffer: Pointer + Collection + AsDatatype {}
 unsafe impl<T> Buffer for T where T: Equivalence {}
 unsafe impl<T> Buffer for [T] where T: Equivalence {}
 unsafe impl<T> Buffer for Vec<T> where T: Equivalence {}
-unsafe impl<T, const D: usize> Buffer for [T; D] where T: Equivalence {}
 
 /// A mutable buffer is a region in memory that starts at `pointer_mut()` and contains `count()`
 /// copies of `as_datatype()`.
@@ -1020,7 +991,6 @@ pub unsafe trait BufferMut: PointerMut + Collection + AsDatatype {}
 unsafe impl<T> BufferMut for T where T: Equivalence {}
 unsafe impl<T> BufferMut for [T] where T: Equivalence {}
 unsafe impl<T> BufferMut for Vec<T> where T: Equivalence {}
-unsafe impl<T, const D: usize> BufferMut for [T; D] where T: Equivalence {}
 
 /// An immutable dynamically-typed buffer.
 ///


### PR DESCRIPTION
This PR resolves the first part of #174, by adding the `Equivalence` trait to arrays, allowing them to be used without wrappers in places which require the trait, such as `ReceiveFuture` or `immediate_send`.

In order to do this, some other trait implementations in `datatype.rs` already covered by a blanket implementation have to be removed to avoid conflict. This does not impact `cargo test` cases passing. If there are significant worries that removing these implementations could change behaviours in strange edge cases, something I could change on review for it is adding it as optional functionality similar to `num-complex`.

Additionally, integration tests for this ergonomic new way of using arrays are added in `arrays.rs`, and checking their equivalence properties in `struct.rs`.