### PR TITLE
Fix process.as_communicator().rank() and examples/structured

### DIFF
--- a/examples/structured.rs
+++ b/examples/structured.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use mpi::{datatype::UserDatatype, traits::*};
+use mpi::{datatype::UserDatatype, topology::Process, traits::*};
 use std::mem::size_of;
 
 struct MyInts([i32; 3]);
@@ -11,6 +11,7 @@ unsafe impl Equivalence for MyInts {
         UserDatatype::structured(
             &[1, 1, 1],
             &[
+                // Order the logical fields in reverse of their storage order
                 (size_of::<i32>() * 2) as mpi::Address,
                 size_of::<i32>() as mpi::Address,
                 0,
@@ -20,18 +21,32 @@ unsafe impl Equivalence for MyInts {
     }
 }
 
+fn prepare_on_root(process: Process, ints: &mut [i32]) {
+    for i in ints.iter_mut() {
+        *i = if process.is_self() { *i + 10 } else { -1 };
+    }
+}
+
 fn main() {
     let universe = mpi::initialize().unwrap();
     let world = universe.world();
 
     let root_process = world.process_at_rank(0);
+    let second_root = world.process_at_rank(1 % world.size());
 
-    if world.rank() == 0 {
-        root_process.broadcast_into(&mut MyInts([3, 2, 1]));
+    if root_process.is_self() {
+        let mut ints = MyInts([3, 2, 1]);
+        root_process.broadcast_into(&mut ints);
+        assert_eq!([3, 2, 1], ints.0);
+        prepare_on_root(second_root, &mut ints.0);
+        second_root.broadcast_into(&mut ints);
+        assert_eq!([13, 12, 11], ints.0);
     } else {
         let mut ints: [i32; 3] = [0, 0, 0];
         root_process.broadcast_into(&mut ints[..]);
-
         assert_eq!([1, 2, 3], ints);
+        prepare_on_root(second_root, &mut ints);
+        second_root.broadcast_into(&mut ints);
+        assert_eq!([11, 12, 13], ints);
     }
 }


### PR DESCRIPTION
* Bug/confusion introduced here: https://github.com/rsmpi/rsmpi/pull/157/files#r1462677040
* Process now holds AnyProcess and returns reference to it in as_communicator()
* Fix denied warning in examples/structured.rs and make more strict
* AnyProcess is now Copy and Clone, like Process
* Add Process::is_self() for common pattern