### PR TITLE
Declare cfg(msmpi) to avoid warnings with 1.80 onward

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    // https://blog.rust-lang.org/2024/05/06/check-cfg.html#buildrs-example
+    println!("cargo:rustc-check-cfg=cfg(msmpi)");
+
     let is_msmpi = match build_probe_mpi::probe() {
         Ok(lib) => lib.version == "MS-MPI",
         _ => false,

--- a/examples/struct.rs
+++ b/examples/struct.rs
@@ -23,13 +23,6 @@ fn main() {
 
     let world = universe.world();
 
-    #[derive(Equivalence)]
-    struct MyProgramOpts {
-        name: [u8; 100],
-        num_cycles: u32,
-        material_properties: [f64; 20],
-    }
-
     #[derive(Equivalence, Default, PartialEq, Debug)]
     struct MyDataRust {
         b: bool,

--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -21,10 +21,6 @@ fn main() {
     let mut builder = cc::Build::new();
     builder.file("src/rsmpi.c");
 
-    if cfg!(windows) {
-        // Adds a cfg to identify MS-MPI
-        println!("cargo:rustc-cfg=msmpi");
-    }
     if let Some(mpicc) = lib.mpicc {
         // Use `mpicc` wrapper when it exists rather than the system C compiler.
         builder.compiler(mpicc);


### PR DESCRIPTION
https://blog.rust-lang.org/2024/05/06/check-cfg.html#buildrs-example

Remove rustc-cfg=msmpi from mpi-sys since the code doesn't use it.