### PR TITLE
mpi-sys: bindgen: use new_type_alias for opaque types

### DIFF
--- a/mpi-sys/build.rs
+++ b/mpi-sys/build.rs
@@ -61,9 +61,14 @@ fn main() {
         }
     }
 
+    let mpi_opaque_types =
+        "MPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win)";
+
     // Generate Rust bindings for the MPI C API.
     let bindings = builder
         .header("src/rsmpi.h")
+        .new_type_alias(mpi_opaque_types)
+        .derive_partialeq(true)
         .emit_builtins()
         .generate()
         .unwrap();


### PR DESCRIPTION
When using MPICH, all the MPI opaque types are typedef'd to int so they can be mixed up without the type checker noticing. This leads to silent bugs when using MPICH (or MSMPI, etc.) that would be compilation errors with Open MPI. Bindgen's new_type_alias() wraps those arguments in newtypes to obtain stricter type checking.