### PR TITLE
feature: add feature 'libffi-system'

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,24 +21,24 @@ jobs:
           - os: ubuntu-latest
             rust: nightly
             mpi_package: libmpich-dev
-            cargo_flags: --all-features
+            cargo_flags: --features user-operations,derive,complex
             cargo_update: true
           - os: ubuntu-latest
             rust: stable
             mpi_package: libmpich-dev
-            cargo_flags: --all-features
+            cargo_flags: --features user-operations,derive,complex
           - os: ubuntu-latest
             rust: 1.70.0
             mpi_package: libmpich-dev
-            cargo_flags: --all-features
+            cargo_flags: --features user-operations,derive,complex
           - os: macos-latest
             rust: stable
             mpi_package: open-mpi
-            cargo_flags: --all-features
+            cargo_flags: --features user-operations,derive,complex
           - os: ubuntu-latest
             rust: stable
             mpi_package: libopenmpi-dev
-            cargo_flags: --all-features
+            cargo_flags: --features user-operations,derive,complex
           - os: windows-2022
             rust: stable
             cargo_flags: --features derive,complex

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
 [features]
 default = ["user-operations"]
 user-operations = ["libffi"]
+libffi-system = ["libffi?/system"]
 derive = ["mpi-derive", "memoffset"]
 complex = ["dep:num-complex"]
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ First, it uses a thin static library written in C (see [rsmpi.h][rsmpih] and [rs
 
 Second, to generate FFI definitions tailored to each MPI implementation, `rsmpi` uses `rust-bindgen` which needs `libclang`. See the [bindgen project page][bindgen] for more information.
 
-Furthermore, `rsmpi` uses the `libffi` crate which installs the native `libffi` which depends on certain build tools. See the [libffi project page][libffi] for more information.
+Furthermore, `rsmpi` uses the `libffi` crate if you use `collective` feature.
+The default behaviour is for libffi to build `libffi.so` from source code using certain build tools, but you can also have it use `libffi.so` installed on your system by enabling the `libffi-system` feature.
+See the [libffi project page][libffi] for more information.
 
 [OpenMPI]: https://www.open-mpi.org
 [MPICH]: https://www.mpich.org


### PR DESCRIPTION
It can be difficult to build `libffi` from source code on some HPC clusters. `libffi` has a feature that uses the system's libraries, which can be specified as a rsmpi feature.

I am working with a GH200 cluster (Miyabi of JCAHPC). The default compiler of this system is `nvc`, but it is difficult to compile `libffi` source code.
The ideal solution is to remove 'libffi' dependency from 'rsmpi or fix `libffi-rs`. However, maintenance of libffi-rs appears to be stalled and it is difficult to remove the libffi dependency from rsmpi.

I think this feature is also useful for other people who use rsmpi in environments that require special compilers.