### PR TITLE
Add bindgen-runtime feature

### DIFF
--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -16,11 +16,15 @@ edition = "2021"
 rust-version = "1.65"
 links = "mpi"
 
+[features]
+default = "bindgen-runtime"
+bindgen-runtime = ["bindgen/runtime"]
+
 [dependencies]
 
 [build-dependencies]
 cc = "1.0.90"
-bindgen = "0.69"
+bindgen = { version = "0.69", default-features = false }
 build-probe-mpi = { path = "../build-probe-mpi", version = "0.1.4" }
 
 [package.metadata.release]


### PR DESCRIPTION
This will allow this bindgen default feature `runtime` to be disabled by using `default-features=false`. This would resolve the issue https://github.com/LIHPC-Computational-Geometry/scotch-rs/issues/12 in scotch-rs