### PR TITLE
Add support for Intel MPI on Windows 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,11 @@ jobs:
             cargo_flags: --all-features
           - os: windows-2025
             rust: stable
+            mpi_package: intelmpi
+            cargo_flags: --all-features
+          - os: windows-2025
+            rust: stable
+            mpi_package: msmpi
             cargo_flags: --features derive,complex
     steps:
       - uses: actions/checkout@v4
@@ -63,11 +68,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install llvm --version 20.1.2 --allow-downgrade -y
-          sh ci/install-mpi-windows.sh
-          echo MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\" | tee -a $GITHUB_ENV
-          echo MSMPI_LIB32="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x86\\" | tee -a $GITHUB_ENV
-          echo MSMPI_LIB64="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\" | tee -a $GITHUB_ENV
-          echo "/c/Program Files/Microsoft MPI/Bin" | tee -a $GITHUB_PATH
+          sh ci/install-mpi-windows.sh ${{ matrix.mpi_package }}
           env
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![GitHub Actions][actions-shield]][actions]
 [![Documentation][doc-shield]][doc]
-[![Crates.io][crate-shield]][crate] 
-[![License: Apache License 2.0 or MIT][license-shield]][license] 
+[![Crates.io][crate-shield]][crate]
+[![License: Apache License 2.0 or MIT][license-shield]][license]
 
 The [Message Passing Interface][MPI] (MPI) is a specification for a
 message-passing style concurrency library. Implementations of MPI are often used to structure
@@ -42,8 +42,9 @@ For a reasonable chance of success with `rsmpi` with any MPI implementation, you
   - export `MPICC=/path/to/mpicc` to specify fully
   - otherwise tries `mpicc` in `$PATH`
   - `mpicc -show` should print the full command line that is used to invoke the wrapped C compiler in gcc-compatible syntax (e.g., `-lmpi`, `-I/usr/local/include`, ...)
-- On Windows, the variables `MSMPI_INC` and either `MSMPI_LIB32` or `MSMPI_LIB64` should be set
-  - see example in [GitHub Actions](.github/workflows/test.yaml)
+- On Windows,
+  - for MS-MPI the variables `MSMPI_INC` and either `MSMPI_LIB32` or `MSMPI_LIB64` should be set
+  - for Intel MPI the variable `I_MPI_ROOT` should be set
 
 Since the MPI standard leaves some details of the C API unspecified (whether to implement certain constants and even functions using preprocessor macros or native C constructs, the details of most types, etc.) `rsmpi` takes a two step approach to generating functional low-level bindings.
 

--- a/build-probe-mpi/src/lib.rs
+++ b/build-probe-mpi/src/lib.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 
 pub use os::probe;
 
-/// Result of a successfull probe
+/// Result of a successful probe
 #[allow(clippy::manual_non_exhaustive)]
 #[derive(Clone, Debug)]
 pub struct Library {

--- a/build-probe-mpi/src/os/windows.rs
+++ b/build-probe-mpi/src/os/windows.rs
@@ -37,12 +37,39 @@ fn var(key: &str) -> Result<String, VarError> {
 
 /// Probe the environment for MS-MPI
 pub fn probe() -> Result<Library, Vec<Box<dyn Error>>> {
-    let mut errs: Vec<Box<dyn Error>> = vec![];
+    let mut intel_errs: Vec<Box<dyn Error>> = vec![];
+
+    // Check for Intel MPI first
+    match var("I_MPI_ROOT") {
+        Ok(oneapi_root) => {
+            let include_path = PathBuf::from(&oneapi_root).join("include");
+
+            let lib_path = if PathBuf::from(&oneapi_root).join("lib/release").exists() {
+                PathBuf::from(&oneapi_root).join("lib/release")
+            } else {
+                PathBuf::from(&oneapi_root).join("lib")
+            };
+
+            return Ok(Library {
+                mpicc: None,
+                libs: vec!["impi".to_owned()],
+                lib_paths: vec![lib_path],
+                include_paths: vec![include_path],
+                version: String::from("Intel MPI"),
+                _priv: (),
+            });
+        }
+        Err(err) => {
+            intel_errs.push(Box::new(err));
+        }
+    }
+
+    let mut msmpi_errs: Vec<Box<dyn Error>> = vec![];
 
     let include_path = match var("MSMPI_INC") {
         Ok(include_path) => Some(include_path),
         Err(err) => {
-            errs.push(Box::new(err));
+            msmpi_errs.push(Box::new(err));
             None
         }
     };
@@ -58,13 +85,15 @@ pub fn probe() -> Result<Library, Vec<Box<dyn Error>>> {
     let lib_path = match var(lib_env) {
         Ok(lib_path) => Some(lib_path),
         Err(err) => {
-            errs.push(Box::new(err));
+            msmpi_errs.push(Box::new(err));
             None
         }
     };
 
-    if errs.len() > 0 {
-        return Err(errs);
+    if msmpi_errs.len() > 0 && intel_errs.len() > 0 {
+        let mut all_errs = msmpi_errs;
+        all_errs.extend(intel_errs);
+        return Err(all_errs);
     }
 
     Ok(Library {

--- a/ci/install-mpi-windows.sh
+++ b/ci/install-mpi-windows.sh
@@ -1,15 +1,95 @@
-echo "Installing MS-MPI SDK..."
+#!/bin/bash
 
-curl -O "https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisdk.msi"
+# Check if an argument is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <mpi_type>"
+    echo "  mpi_type: msmpi or intelmpi"
+    exit 1
+fi
 
-msiexec.exe //i msmpisdk.msi //quiet //qn //log ./install.log
+MPI_TYPE=$1
 
-echo "Installed MS-MPI SDK!"
+# Function to install Intel MPI on Windows
+# reference: https://github.com/mpi4py/setup-mpi/blob/master/setup-mpi.sh
+setup_win_intel_oneapi_mpi () {
+    hash="edf463a6-a6ad-43d2-a588-daa2e30f8735" 
+    version="2021.15.0" 
+    build="496"
+    baseurl="https://registrationcenter-download.intel.com"
+    subpath="akdlm/IRC_NAS/$hash"
+    package="intel-mpi-${version}.${build}_offline.exe"
+    set -x
+    curl -sO "$baseurl/$subpath/$package"
+    ./"$package" -s -a --silent --eula accept
+    set +x
+}
 
-echo "Installing MS-MPI Redist..."
+setup_win_intel_oneapi_mpi_env () {
+    ONEAPI_ROOT="C:\Program Files (x86)\Intel\oneAPI"
+    I_MPI_ROOT="${ONEAPI_ROOT}\mpi\latest"
+    I_MPI_OFI_LIBRARY_INTERNAL="1"
+    I_MPI_BIN="${I_MPI_ROOT}\bin"
+    I_MPI_LIBFABRIC_BIN="${I_MPI_ROOT}\opt\mpi\libfabric\bin"
 
-curl -O "https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisetup.exe"
+    echo "ONEAPI_ROOT=${ONEAPI_ROOT}" >> $GITHUB_ENV
+    echo "I_MPI_ROOT=${I_MPI_ROOT}" >> $GITHUB_ENV
+    echo "I_MPI_OFI_LIBRARY_INTERNAL=${I_MPI_OFI_LIBRARY_INTERNAL}" >> $GITHUB_ENV
+    echo "${I_MPI_BIN}" >> $GITHUB_PATH
+    echo "${I_MPI_LIBFABRIC_BIN}" >> $GITHUB_PATH
 
-./msmpisetup.exe -unattend -full
+    export PATH="$(cygpath -u "${I_MPI_BIN}"):$PATH"
+    export PATH="$(cygpath -u "${I_MPI_LIBFABRIC_BIN}"):$PATH"
+}
 
-echo "Installed MS-MPI Redist!"
+setup_win_ms_mpi_env () {
+    MSMPI_INC="C:\Program Files (x86)\Microsoft SDKs\MPI\Include"
+    MSMPI_LIB32="C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x86"
+    MSMPI_LIB64="C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64"
+    MSMPI_BIN="C:\Program Files\Microsoft MPI\Bin"
+
+    echo "MSMPI_INC=${MSMPI_INC}" >> $GITHUB_ENV
+    echo "MSMPI_LIB32=${MSMPI_LIB32}" >> $GITHUB_ENV
+    echo "MSMPI_LIB64=${MSMPI_LIB64}" >> $GITHUB_ENV
+    echo "${MSMPI_BIN}" >> $GITHUB_PATH
+
+    export PATH="$(cygpath -u "${MSMPI_BIN}"):$PATH"
+}
+
+case "$MPI_TYPE" in
+    msmpi)
+        echo "Installing MS-MPI SDK..."
+
+        curl -O "https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisdk.msi"
+
+        msiexec.exe //i msmpisdk.msi //quiet //qn //log ./install.log
+
+        echo "Installed MS-MPI SDK!"
+
+        echo "Installing MS-MPI Redist..."
+
+        curl -O "https://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisetup.exe"
+
+        ./msmpisetup.exe -unattend -full
+
+        setup_win_ms_mpi_env
+
+        echo "Installed MS-MPI Redist!"
+        ;;
+
+    intelmpi)
+        echo "Installing Intel MPI..."
+
+        setup_win_intel_oneapi_mpi
+        setup_win_intel_oneapi_mpi_env
+        hydra_service.exe -install
+
+        echo "Installed Intel MPI!"
+        ;;
+
+    *)
+        echo "Error: Invalid MPI type '$MPI_TYPE'"
+        echo "Usage: $0 <mpi_type>"
+        echo "  mpi_type: msmpi or intelmpi"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR is related to issue #204

This pull request includes several changes to the GitHub Actions workflows, documentation, and code related to MPI (Message Passing Interface) support. The most important changes involve updating the MPI packages used in the workflows, improving support for different MPI implementations on Windows, and fixing a typo in the code.

### Workflow Updates:
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L23-R71):  Added support for `intelmpi` on Windows.
* [`ci/install-mpi-windows.sh`](diffhunk://#diff-e8612bf247b5ea5fde5483d3e7528c5d8c9566adddd4c7b9a2a17f3b424b6ec2L1-L15): Update the script for installing MS-MPI on Windows, it will now handle intel MPI and MS-MPI

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R47): Updated instructions for setting environment variables for MS-MPI and Intel MPI on Windows. 

