### PR TITLE
Update libffi to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ complex = ["dep:num-complex"]
 
 [dependencies]
 conv = "0.3.3"
-libffi = { version = "3.2.0", optional = true }
+libffi = { version = "4.0.0", optional = true }
 memoffset = { version = "0.9", optional = true }
 mpi-derive = { path = "mpi-derive", version = "0.1.2", optional = true }
 mpi-sys = { path = "mpi-sys", version = "0.2.2" }


### PR DESCRIPTION
LIbffi is broken in MacOS 15+. The clang compiler that comes with Xcode that comes with MacOS 15 is incompatible with libffi 3.2.0. 

There has been a fix, and it is updated in libffi 4.0.0. See https://github.com/tov/libffi-rs/issues/109