### PR TITLE
MPI-forum.org links have moved, update links in this project

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //! most of the descriptions are quite terse for now and to the uninitiated will only make sense in
 //! combination with the [MPI specification][MPIspec].
 //!
-//! [MPIspec]: http://www.mpi-forum.org/docs/docs.html
+//! [MPIspec]: https://www.mpi-forum.org/docs/
 
 use std::{mem::MaybeUninit, os::raw::c_int};
 
@@ -129,7 +129,7 @@ use std::{mem::MaybeUninit, os::raw::c_int};
 ///
 /// Documented in the [Message Passing Interface specification][spec]
 ///
-/// [spec]: http://www.mpi-forum.org/docs/docs.html
+/// [spec]: https://www.mpi-forum.org/docs/
 #[allow(missing_docs, dead_code, non_snake_case, non_camel_case_types)]
 #[macro_use]
 pub mod ffi {


### PR DESCRIPTION
At some point the links to mpi-forum.org broke - this PR simply changes two links to the page they originally pointed to in order to fix a 404 error.