### PR TITLE
Fix OpenMPI with Clang-22: bindgen missing field on type `ompi_status_public_t`

### DIFF
--- a/mpi-sys/Cargo.toml
+++ b/mpi-sys/Cargo.toml
@@ -20,7 +20,7 @@ links = "mpi"
 
 [build-dependencies]
 cc = "1.2.49"
-bindgen = { version = "0.69.5", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"] }
 build-probe-mpi = { path = "../build-probe-mpi", version = "0.1.5" }
 
 [package.metadata.release]


### PR DESCRIPTION
Hi devs!

This PR only merely updates version of `bindgen` in crate `mpi-sys` from 0.69.5 -> 0.72.1.

The version update may resolve the problem when using OpenMPI together with libclang-22, which has described in #218.
The bindgen version 0.72.1 should have implemented the bug fix (https://github.com/rust-lang/rust-bindgen/compare/v0.72.0...v0.72.1). So I believe updates the crate bindgen version can fix #218.